### PR TITLE
DayExercise CRUD (API)

### DIFF
--- a/apps/api/prisma/migrations/20260126070410_dayexercise_order_unique/migration.sql
+++ b/apps/api/prisma/migrations/20260126070410_dayexercise_order_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[programDayId,order]` on the table `DayExercise` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "DayExercise_programDayId_order_key" ON "DayExercise"("programDayId", "order");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -58,4 +58,5 @@ model DayExercise {
   targetSets   Int
   minReps      Int
   maxReps      Int
+  @@unique([programDayId, order])
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,9 +3,10 @@ import { HealthModule } from './modules/health/health.module';
 import { PrismaModule } from './modules/prisma/prisma.module';
 import { ProgramsModule } from './modules/programs/programs.module';
 import { ProgramDaysModule } from './modules/program-days/program-days.module';
+import { DayExercisesModule } from './modules/day-exercises/day-exercises.module';
 
 
 @Module({
-  imports: [HealthModule, PrismaModule, ProgramsModule, ProgramDaysModule],
+  imports: [HealthModule, PrismaModule, ProgramsModule, ProgramDaysModule, DayExercisesModule],
 })
 export class AppModule {}

--- a/apps/api/src/modules/day-exercises/day-exercises.controller.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { DayExercisesService } from './day-exercises.service';
+import { CreateDayExerciseDto } from './dto/create-day-exercise.dto';
+import { UpdateDayExerciseDto } from './dto/update-day-exercise.dto';
+
+@Controller('programs/:programId/days/:dayId/exercises')
+export class DayExercisesController {
+  constructor(private readonly dayExercisesService: DayExercisesService) {}
+
+  @Post()
+  create(
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+    @Body() dto: CreateDayExerciseDto,
+  ) {
+    return this.dayExercisesService.create(programId, dayId, dto);
+  }
+
+  @Get()
+  findAll(
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+  ) {
+    return this.dayExercisesService.findAll(programId, dayId);
+  }
+
+  @Patch(':dayExerciseId')
+  update(
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+    @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
+    @Body() dto: UpdateDayExerciseDto,
+  ) {
+    return this.dayExercisesService.update(programId, dayId, dayExerciseId, dto);
+  }
+
+  @Delete(':dayExerciseId')
+  async remove(
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+    @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
+  ) {
+    await this.dayExercisesService.remove(programId, dayId, dayExerciseId);
+    return { ok: true };
+  }
+}

--- a/apps/api/src/modules/day-exercises/day-exercises.module.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DayExercisesController } from './day-exercises.controller';
+import { DayExercisesService } from './day-exercises.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [DayExercisesController],
+  providers: [DayExercisesService],
+})
+export class DayExercisesModule {}

--- a/apps/api/src/modules/day-exercises/day-exercises.service.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.service.ts
@@ -1,0 +1,130 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { DayExercise, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateDayExerciseDto } from './dto/create-day-exercise.dto';
+import { UpdateDayExerciseDto } from './dto/update-day-exercise.dto';
+
+@Injectable()
+export class DayExercisesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private validateRepRange(minReps?: number, maxReps?: number) {
+    if (minReps !== undefined && maxReps !== undefined && minReps > maxReps) {
+      throw new BadRequestException('minReps must be <= maxReps');
+    }
+  }
+
+  private async ensureProgramExists(programId: number) {
+    const program = await this.prisma.program.findUnique({
+      where: { id: programId },
+      select: { id: true },
+    });
+    if (!program) throw new NotFoundException('Program not found');
+  }
+
+  private async ensureDayExists(programId: number, dayId: number) {
+    await this.ensureProgramExists(programId);
+
+    const day = await this.prisma.programDay.findFirst({
+      where: { id: dayId, programId },
+      select: { id: true },
+    });
+
+    if (!day) throw new NotFoundException('Program day not found');
+  }
+
+  async create(
+    programId: number,
+    dayId: number,
+    dto: CreateDayExerciseDto,
+  ): Promise<DayExercise> {
+    await this.ensureDayExists(programId, dayId);
+    this.validateRepRange(dto.minReps, dto.maxReps);
+
+    const exercise = await this.prisma.exercise.findUnique({
+      where: { id: dto.exerciseId },
+      select: { id: true },
+    });
+    if (!exercise) throw new NotFoundException('Exercise not found');
+
+    try {
+      return await this.prisma.dayExercise.create({
+        data: {
+          programDayId: dayId,
+          exerciseId: dto.exerciseId,
+          order: dto.order,
+          targetSets: dto.targetSets,
+          minReps: dto.minReps,
+          maxReps: dto.maxReps,
+        },
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new ConflictException('Exercise order already exists for this day');
+      }
+      throw e;
+    }
+  }
+
+  async findAll(programId: number, dayId: number): Promise<DayExercise[]> {
+    await this.ensureDayExists(programId, dayId);
+
+    return this.prisma.dayExercise.findMany({
+      where: { programDayId: dayId },
+      orderBy: { order: 'asc' },
+    });
+  }
+
+  async update(
+    programId: number,
+    dayId: number,
+    dayExerciseId: number,
+    dto: UpdateDayExerciseDto,
+  ): Promise<DayExercise> {
+    await this.ensureDayExists(programId, dayId);
+
+    this.validateRepRange(dto.minReps, dto.maxReps);
+
+    const existing = await this.prisma.dayExercise.findFirst({
+      where: { id: dayExerciseId, programDayId: dayId },
+    });
+    if (!existing) throw new NotFoundException('Day exercise not found');
+
+    if (dto.exerciseId !== undefined) {
+      const exercise = await this.prisma.exercise.findUnique({
+        where: { id: dto.exerciseId },
+        select: { id: true },
+      });
+      if (!exercise) throw new NotFoundException('Exercise not found');
+    }
+
+    try {
+      return await this.prisma.dayExercise.update({
+        where: { id: dayExerciseId },
+        data: dto,
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        throw new ConflictException('Exercise order already exists for this day');
+      }
+      throw e;
+    }
+  }
+
+  async remove(programId: number, dayId: number, dayExerciseId: number): Promise<void> {
+    await this.ensureDayExists(programId, dayId);
+
+    const existing = await this.prisma.dayExercise.findFirst({
+      where: { id: dayExerciseId, programDayId: dayId },
+      select: { id: true },
+    });
+    if (!existing) throw new NotFoundException('Day exercise not found');
+
+    await this.prisma.dayExercise.delete({ where: { id: dayExerciseId } });
+  }
+}

--- a/apps/api/src/modules/day-exercises/dto/create-day-exercise.dto.ts
+++ b/apps/api/src/modules/day-exercises/dto/create-day-exercise.dto.ts
@@ -1,0 +1,23 @@
+import { IsInt, Min } from 'class-validator';
+
+export class CreateDayExerciseDto {
+  @IsInt()
+  @Min(1)
+  exerciseId!: number;
+
+  @IsInt()
+  @Min(1)
+  order!: number;
+
+  @IsInt()
+  @Min(1)
+  targetSets!: number;
+
+  @IsInt()
+  @Min(1)
+  minReps!: number;
+
+  @IsInt()
+  @Min(1)
+  maxReps!: number;
+}

--- a/apps/api/src/modules/day-exercises/dto/update-day-exercise.dto.ts
+++ b/apps/api/src/modules/day-exercises/dto/update-day-exercise.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateDayExerciseDto } from './create-day-exercise.dto';
+
+export class UpdateDayExerciseDto extends PartialType(CreateDayExerciseDto) {}


### PR DESCRIPTION
## What
Add DayExercise CRUD under ProgramDay, allowing attaching exercises to a day with ordering and rep/sets targets.


## Why
This is a core building block for workout planning and future workout sessions + analytics.


## How to test
- Create Program
- Create ProgramDay
- Create Exercises (via Prisma Studio)
- POST /api/programs/:programId/days/:dayId/exercises
- GET list, PATCH update, DELETE
- Verify 409 on duplicate order and 400 on invalid rep range


## Closes
Closes #9