### PR TITLE
Exercise CRUD (API) + seed

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "prisma:seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/apps/api/prisma/migrations/20260126114756_exercise_unique_name/migration.sql
+++ b/apps/api/prisma/migrations/20260126114756_exercise_unique_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Exercise` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Exercise_name_key" ON "Exercise"("name");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -13,50 +7,52 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum ProgramType {
-AB
-PPL
-FULL_BODY
-CUSTOM
-}
-
 model Program {
   id        Int          @id @default(autoincrement())
   name      String
-  type      ProgramType
   isActive  Boolean      @default(false)
-  days      ProgramDay[]
   createdAt DateTime     @default(now())
-  updatedAt DateTime @updatedAt
+  updatedAt DateTime     @updatedAt
+  type      ProgramType
+  days      ProgramDay[]
 }
 
 model ProgramDay {
   id        Int           @id @default(autoincrement())
   name      String
   order     Int
-  program   Program       @relation(fields: [programId], references: [id])
   programId Int
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
   exercises DayExercise[]
-  createdAt DateTime     @default(now())
-  updatedAt DateTime @updatedAt
+  program   Program       @relation(fields: [programId], references: [id])
+
   @@unique([programId, order])
 }
 
 model Exercise {
   id        Int           @id @default(autoincrement())
-  name      String
+  name      String        @unique
   exercises DayExercise[]
 }
 
 model DayExercise {
   id           Int        @id @default(autoincrement())
-  programDay   ProgramDay @relation(fields: [programDayId], references: [id])
   programDayId Int
-  exercise     Exercise   @relation(fields: [exerciseId], references: [id])
   exerciseId   Int
   order        Int
   targetSets   Int
   minReps      Int
   maxReps      Int
+  exercise     Exercise   @relation(fields: [exerciseId], references: [id])
+  programDay   ProgramDay @relation(fields: [programDayId], references: [id])
+
   @@unique([programDayId, order])
+}
+
+enum ProgramType {
+  AB
+  PPL
+  FULL_BODY
+  CUSTOM
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const exercises = [
+  'Bench Press',
+  'Squat',
+  'Deadlift',
+  'Overhead Press',
+  'Pull Up',
+  'Lat Pulldown',
+  'Barbell Row',
+  'Dumbbell Curl',
+  'Triceps Pushdown',
+  'Leg Press',
+];
+
+async function main() {
+  for (const name of exercises) {
+    await prisma.exercise.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,9 +4,10 @@ import { PrismaModule } from './modules/prisma/prisma.module';
 import { ProgramsModule } from './modules/programs/programs.module';
 import { ProgramDaysModule } from './modules/program-days/program-days.module';
 import { DayExercisesModule } from './modules/day-exercises/day-exercises.module';
+import { ExercisesModule } from './modules/exercises/exercises.module';
 
 
 @Module({
-  imports: [HealthModule, PrismaModule, ProgramsModule, ProgramDaysModule, DayExercisesModule],
+  imports: [HealthModule, PrismaModule, ProgramsModule, ProgramDaysModule, DayExercisesModule, ExercisesModule],
 })
 export class AppModule {}

--- a/apps/api/src/modules/exercises/dto/create-exercise.dto.ts
+++ b/apps/api/src/modules/exercises/dto/create-exercise.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateExerciseDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+}

--- a/apps/api/src/modules/exercises/dto/update-exercise.dto.ts
+++ b/apps/api/src/modules/exercises/dto/update-exercise.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateExerciseDto } from './create-exercise.dto';
+
+export class UpdateExerciseDto extends PartialType(CreateExerciseDto) {}

--- a/apps/api/src/modules/exercises/exercises.controller.ts
+++ b/apps/api/src/modules/exercises/exercises.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ExercisesService } from './exercises.service';
+import { CreateExerciseDto } from './dto/create-exercise.dto';
+import { UpdateExerciseDto } from './dto/update-exercise.dto';
+
+@Controller('exercises')
+export class ExercisesController {
+  constructor(private readonly exercisesService: ExercisesService) {}
+
+  @Post()
+  create(@Body() dto: CreateExerciseDto) {
+    return this.exercisesService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.exercisesService.findAll();
+  }
+
+  @Get(':exerciseId')
+  findOne(@Param('exerciseId', ParseIntPipe) id: number) {
+    return this.exercisesService.findOne(id);
+  }
+
+  @Patch(':exerciseId')
+  update(
+    @Param('exerciseId', ParseIntPipe) id: number,
+    @Body() dto: UpdateExerciseDto,
+  ) {
+    return this.exercisesService.update(id, dto);
+  }
+
+  @Delete(':exerciseId')
+  async remove(@Param('exerciseId', ParseIntPipe) id: number) {
+    await this.exercisesService.remove(id);
+    return { ok: true };
+  }
+}

--- a/apps/api/src/modules/exercises/exercises.module.ts
+++ b/apps/api/src/modules/exercises/exercises.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ExercisesController } from './exercises.controller';
+import { ExercisesService } from './exercises.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ExercisesController],
+  providers: [ExercisesService]
+})
+export class ExercisesModule {}

--- a/apps/api/src/modules/exercises/exercises.service.ts
+++ b/apps/api/src/modules/exercises/exercises.service.ts
@@ -1,0 +1,79 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Exercise, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExerciseDto } from './dto/create-exercise.dto';
+import { UpdateExerciseDto } from './dto/update-exercise.dto';
+
+@Injectable()
+export class ExercisesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private normalizeName(name: string): string {
+    return name.trim();
+  }
+
+  async create(dto: CreateExerciseDto): Promise<Exercise> {
+    const name = this.normalizeName(dto.name);
+
+    try {
+      return await this.prisma.exercise.create({
+        data: { name },
+      });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException('Exercise with this name already exists');
+      }
+      throw e;
+    }
+  }
+
+  async findAll(): Promise<Exercise[]> {
+    return this.prisma.exercise.findMany({
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async findOne(id: number): Promise<Exercise> {
+    const exercise = await this.prisma.exercise.findUnique({
+      where: { id },
+    });
+    if (!exercise) throw new NotFoundException('Exercise not found');
+    return exercise;
+  }
+
+  async update(
+    id: number,
+    dto: UpdateExerciseDto,
+  ): Promise<Exercise> {
+    await this.findOne(id);
+
+    try {
+      return await this.prisma.exercise.update({
+        where: { id },
+        data: dto.name
+          ? { name: this.normalizeName(dto.name) }
+          : {},
+      });
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException('Exercise with this name already exists');
+      }
+      throw e;
+    }
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.findOne(id);
+    await this.prisma.exercise.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## What
- Add Exercise CRUD endpoints
- Enforce unique exercise names via Prisma
- Add idempotent seed script for common exercises

## Why
Exercise catalog is required to build real program flows without manual DB inserts and enables future analytics/suggestions.

## How to test
1. Run API + DB
2. Seed: `npm run prisma:seed` (or `npx ts-node prisma/seed.ts`)
3. `GET /api/exercises` returns seeded items
4. `POST /api/exercises` creates a new exercise
5. Duplicate name returns 409

## Closes
Closes #11