### PR TITLE
Program Read Model (API)

### DIFF
--- a/apps/api/src/modules/programs/programs.controller.ts
+++ b/apps/api/src/modules/programs/programs.controller.ts
@@ -14,7 +14,7 @@ import { UpdateProgramDto } from './dto/update-program.dto';
 
 @Controller('programs')
 export class ProgramsController {
-  constructor(private readonly programsService: ProgramsService) {}
+  constructor(private readonly programsService: ProgramsService) { }
 
   @Post()
   create(@Body() dto: CreateProgramDto) {
@@ -29,6 +29,11 @@ export class ProgramsController {
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.programsService.findOne(id);
+  }
+
+  @Get(':id/detailed')
+  findOneDetailed(@Param('id', ParseIntPipe) id: number) {
+    return this.programsService.findOneDetailed(id);
   }
 
   @Patch(':id')

--- a/apps/api/src/modules/programs/programs.service.ts
+++ b/apps/api/src/modules/programs/programs.service.ts
@@ -49,4 +49,26 @@ export class ProgramsService {
       throw e;
     }
   }
+
+  async findOneDetailed(id: number) {
+  const program = await this.prisma.program.findUnique({
+    where: { id },
+    include: {
+      days: {
+        orderBy: { order: 'asc' },
+        include: {
+          exercises: {
+            orderBy: { order: 'asc' },
+            include: {
+              exercise: { select: { id: true, name: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!program) throw new NotFoundException('Program not found');
+  return program;
+}
 }


### PR DESCRIPTION
## What
Add a detailed program read endpoint that returns nested days and day exercises including exercise name.

## Why
Frontend program screens require a single request that returns the full program structure with correct ordering.

## How to test
1. Create Program + Days + DayExercises
2. Call GET /api/programs/:id/detailed
3. Verify ordering and nested exercise data

## Closes
Closes #13