### PR TITLE
feat(workouts): workout session read model + sessions list

### DIFF
--- a/apps/api/src/modules/workouts/workouts.controller.ts
+++ b/apps/api/src/modules/workouts/workouts.controller.ts
@@ -15,6 +15,11 @@ import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
 export class WorkoutsController {
   constructor(private readonly workoutsService: WorkoutsService) { }
 
+  @Get()
+  findAll() {
+    return this.workoutsService.findAll();
+  }
+
   @Post('start')
   start(@Body() dto: StartWorkoutSessionDto) {
     return this.workoutsService.start(dto);
@@ -25,7 +30,7 @@ export class WorkoutsController {
     return this.workoutsService.getSession(sessionId);
   }
 
-  @Get('sessions/:sessionId')
+  @Get(':sessionId/details')
   findOneDetailed(
     @Param('sessionId', ParseIntPipe) sessionId: number,
   ) {

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -97,6 +97,20 @@ export class WorkoutsService {
     });
   }
 
+  async findAll() {
+    return this.prisma.workoutSession.findMany({
+      orderBy: { startedAt: 'desc' },
+      select: {
+        id: true,
+        startedAt: true,
+        endedAt: true,
+        program: { select: { id: true, name: true, type: true } },
+        programDay: { select: { id: true, name: true, order: true } },
+        _count: { select: { sets: true } },
+      },
+    });
+  }
+
   async findOneDetailed(sessionId: number) {
     const session = await this.prisma.workoutSession.findUnique({
       where: { id: sessionId },
@@ -106,9 +120,46 @@ export class WorkoutsService {
       },
     });
 
+
     if (!session) {
       throw new NotFoundException('Workout session not found');
     }
+
+    const plannedExercises = await this.prisma.dayExercise.findMany({
+      where: { programDayId: session.programDayId },
+      orderBy: { order: 'asc' },
+      include: {
+        exercise: { select: { id: true, name: true } },
+      },
+    });
+
+    const performedSets = await this.prisma.workoutSet.findMany({
+      where: { sessionId: session.id },
+      orderBy: { setNumber: 'asc' },
+    });
+
+    const setsByDayExerciseId = new Map<
+      number,
+      { setNumber: number; reps: number; weight: number }[]
+    >();
+
+    for (const s of performedSets) {
+      const arr = setsByDayExerciseId.get(s.dayExerciseId) ?? [];
+      arr.push({ setNumber: s.setNumber, reps: s.reps, weight: s.weight });
+      setsByDayExerciseId.set(s.dayExerciseId, arr);
+    }
+
+    const exercises = plannedExercises.map((de) => ({
+      dayExercise: {
+        id: de.id,
+        order: de.order,
+        targetSets: de.targetSets,
+        minReps: de.minReps,
+        maxReps: de.maxReps,
+        exercise: de.exercise, // { id, name }
+      },
+      performedSets: setsByDayExerciseId.get(de.id) ?? [],
+    }));
 
     return {
       id: session.id,
@@ -116,7 +167,7 @@ export class WorkoutsService {
       endedAt: session.endedAt,
       program: session.program,
       programDay: session.programDay,
-      // exercises: ... (כשתוסיף את ה-read model המלא של planned vs performed)
+      exercises,
     };
   }
 }


### PR DESCRIPTION
## What
- Add workout sessions listing endpoint
- Add detailed workout session read model (planned vs performed)
- Clean up workouts routes to avoid `sessions/sessions` duplication

## Endpoints
- GET  /api/workouts/sessions
- GET  /api/workouts/sessions/:sessionId/details

## How it works
- Fetch session + program + programDay
- Fetch planned DayExercises for the session's ProgramDay (ordered)
- Fetch performed WorkoutSets for the session (ordered)
- Build a combined response where each planned exercise includes its performed sets

## How to test
1. Start a session:
   - POST /api/workouts/sessions/start
2. Add a set:
   - POST /api/workouts/sessions/:sessionId/sets
3. Verify details read model:
   - GET /api/workouts/sessions/:sessionId/details
4. Verify sessions list:
   - GET /api/workouts/sessions

## Closes
Closes #17