### PR TITLE
feat(exercises): add exercise progress endpoint with history and PRs

### DIFF
--- a/apps/api/src/modules/exercises/exercises.controller.ts
+++ b/apps/api/src/modules/exercises/exercises.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { ExercisesService } from './exercises.service';
 import { CreateExerciseDto } from './dto/create-exercise.dto';
@@ -14,7 +15,7 @@ import { UpdateExerciseDto } from './dto/update-exercise.dto';
 
 @Controller('exercises')
 export class ExercisesController {
-  constructor(private readonly exercisesService: ExercisesService) {}
+  constructor(private readonly exercisesService: ExercisesService) { }
 
   @Post()
   create(@Body() dto: CreateExerciseDto) {
@@ -43,5 +44,16 @@ export class ExercisesController {
   async remove(@Param('exerciseId', ParseIntPipe) id: number) {
     await this.exercisesService.remove(id);
     return { ok: true };
+  }
+
+  @Get(':exerciseId/progress')
+  getProgress(
+    @Param('exerciseId', ParseIntPipe) exerciseId: number,
+    @Query('limit') limit?: string,
+    @Query('cursor') cursor?: string,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.exercisesService.getProgress(exerciseId, { limit, cursor, from, to });
   }
 }

--- a/apps/api/src/modules/exercises/exercises.service.ts
+++ b/apps/api/src/modules/exercises/exercises.service.ts
@@ -2,11 +2,19 @@ import {
   ConflictException,
   Injectable,
   NotFoundException,
+  BadRequestException,
 } from '@nestjs/common';
 import { Exercise, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateExerciseDto } from './dto/create-exercise.dto';
 import { UpdateExerciseDto } from './dto/update-exercise.dto';
+
+type ProgressQuery = {
+  limit?: string;
+  cursor?: string;
+  from?: string;
+  to?: string;
+};
 
 @Injectable()
 export class ExercisesService {
@@ -24,10 +32,7 @@ export class ExercisesService {
         data: { name },
       });
     } catch (e) {
-      if (
-        e instanceof Prisma.PrismaClientKnownRequestError &&
-        e.code === 'P2002'
-      ) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         throw new ConflictException('Exercise with this name already exists');
       }
       throw e;
@@ -48,24 +53,16 @@ export class ExercisesService {
     return exercise;
   }
 
-  async update(
-    id: number,
-    dto: UpdateExerciseDto,
-  ): Promise<Exercise> {
+  async update(id: number, dto: UpdateExerciseDto): Promise<Exercise> {
     await this.findOne(id);
 
     try {
       return await this.prisma.exercise.update({
         where: { id },
-        data: dto.name
-          ? { name: this.normalizeName(dto.name) }
-          : {},
+        data: dto.name ? { name: this.normalizeName(dto.name) } : {},
       });
     } catch (e) {
-      if (
-        e instanceof Prisma.PrismaClientKnownRequestError &&
-        e.code === 'P2002'
-      ) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         throw new ConflictException('Exercise with this name already exists');
       }
       throw e;
@@ -75,5 +72,163 @@ export class ExercisesService {
   async remove(id: number): Promise<void> {
     await this.findOne(id);
     await this.prisma.exercise.delete({ where: { id } });
+  }
+
+  async getProgress(exerciseId: number, q: ProgressQuery) {
+    // 1) validate exercise exists
+    const exercise = await this.prisma.exercise.findUnique({
+      where: { id: exerciseId },
+      select: { id: true, name: true },
+    });
+    if (!exercise) throw new NotFoundException('Exercise not found');
+
+    // 2) parse query params
+    const takeRaw = q.limit ? Number(q.limit) : 100;
+    if (!Number.isFinite(takeRaw) || takeRaw <= 0) {
+      throw new BadRequestException('limit must be a positive number');
+    }
+    const take = Math.min(takeRaw, 500);
+
+    let cursorId: number | undefined;
+    if (q.cursor !== undefined) {
+      const parsed = Number(q.cursor);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new BadRequestException('cursor must be a positive integer');
+      }
+      cursorId = parsed;
+    }
+
+    const fromDate = q.from ? new Date(q.from) : undefined;
+    if (q.from && Number.isNaN(fromDate!.getTime())) {
+      throw new BadRequestException('from must be a valid ISO date');
+    }
+
+    const toDate = q.to ? new Date(q.to) : undefined;
+    if (q.to && Number.isNaN(toDate!.getTime())) {
+      throw new BadRequestException('to must be a valid ISO date');
+    }
+
+    // 3) build where for HISTORY (paged)
+    const whereHistory: Prisma.WorkoutSetWhereInput = {
+      dayExercise: { exerciseId },
+    };
+
+    if (fromDate || toDate) {
+      whereHistory.createdAt = {};
+      if (fromDate) whereHistory.createdAt.gte = fromDate;
+      if (toDate) whereHistory.createdAt.lte = toDate;
+    }
+
+    // Cursor pagination: id < cursor (descending by id)
+    if (cursorId) {
+      whereHistory.id = { lt: cursorId };
+    }
+
+    // 4) query sets for history (paged)
+    const sets = await this.prisma.workoutSet.findMany({
+      where: whereHistory,
+      take,
+      orderBy: [{ id: 'desc' }], // stable pagination by id
+      select: {
+        id: true,
+        reps: true,
+        weight: true,
+        createdAt: true,
+        sessionId: true,
+        session: {
+          select: {
+            id: true,
+            program: { select: { id: true, name: true, type: true } },
+            programDay: { select: { id: true, name: true, order: true } },
+          },
+        },
+      },
+    });
+
+    const history = sets.map((s) => {
+      const volume = s.reps * s.weight;
+      return {
+        performedAt: s.createdAt,
+        weight: s.weight,
+        reps: s.reps,
+        volume,
+        sessionId: s.sessionId,
+        program: s.session.program,
+        programDay: s.session.programDay,
+      };
+    });
+
+    const nextCursor = sets.length === take ? sets[sets.length - 1].id : null;
+
+    // 5) PRs: all-time (NOT affected by limit/cursor/from/to)
+    const prWhere: Prisma.WorkoutSetWhereInput = {
+      dayExercise: { exerciseId },
+    };
+
+    // best weight set: highest weight, tie: reps desc, then newest
+    const bestWeightRow = await this.prisma.workoutSet.findFirst({
+      where: prWhere,
+      orderBy: [{ weight: 'desc' }, { reps: 'desc' }, { createdAt: 'desc' }],
+      select: { weight: true, reps: true, createdAt: true, sessionId: true },
+    });
+
+    const bestWeightSet = bestWeightRow
+      ? {
+          weight: bestWeightRow.weight,
+          reps: bestWeightRow.reps,
+          performedAt: bestWeightRow.createdAt,
+          sessionId: bestWeightRow.sessionId,
+        }
+      : null;
+
+    // best volume set: compute exact max(reps * weight) in TS
+    // (small select to keep it light)
+    const allTimeRows = await this.prisma.workoutSet.findMany({
+      where: prWhere,
+      select: { weight: true, reps: true, createdAt: true, sessionId: true },
+    });
+
+    let bestVolumeSet: {
+      weight: number;
+      reps: number;
+      volume: number;
+      performedAt: Date;
+      sessionId: number;
+    } | null = null;
+
+    for (const r of allTimeRows) {
+      const volume = r.weight * r.reps;
+
+      if (
+        !bestVolumeSet ||
+        volume > bestVolumeSet.volume ||
+        (volume === bestVolumeSet.volume && r.weight > bestVolumeSet.weight) ||
+        (volume === bestVolumeSet.volume &&
+          r.weight === bestVolumeSet.weight &&
+          r.reps > bestVolumeSet.reps) ||
+        (volume === bestVolumeSet.volume &&
+          r.weight === bestVolumeSet.weight &&
+          r.reps === bestVolumeSet.reps &&
+          r.createdAt > bestVolumeSet.performedAt)
+      ) {
+        bestVolumeSet = {
+          weight: r.weight,
+          reps: r.reps,
+          volume,
+          performedAt: r.createdAt,
+          sessionId: r.sessionId,
+        };
+      }
+    }
+
+    return {
+      exercise,
+      prs: {
+        bestWeightSet,
+        bestVolumeSet,
+      },
+      history,
+      nextCursor,
+    };
   }
 }


### PR DESCRIPTION
## What
Add exercise-level progress API exposing history and personal records (PRs)
based on performed workout sets.

## Why
This endpoint provides the analytical foundation for:
- Exercise progress screens (tables / charts)
- Personal record detection
- Future UX features (smart defaults, comparisons, recommendations)

## Endpoints
- GET /api/exercises/:exerciseId/progress

## Features
- Full history of performed sets for a given exercise
- Personal records:
  - Best weight set
  - Best volume set (reps * weight)
- Deterministic tie-breakers for PRs
- Cursor-based pagination
- Optional date filtering (from / to)
- Works for unfinished sessions

## Implementation Details
- Query WorkoutSet joined through DayExercise -> Exercise
- Join Session -> Program + ProgramDay to enrich history context
- Aggregations performed in service layer
- No raw Prisma entities exposed directly
- Stable ordering (newest first)

## How to Test
1. Perform multiple sets for the same exercise across sessions
2. Call:
   GET /api/exercises/:exerciseId/progress
3. Verify:
   - History is ordered by most recent
   - PRs reflect highest weight and highest volume
   - Pagination works using cursor
   - 404 returned for non-existing exercise

## Notes
- This PR intentionally does NOT modify addSet behavior
- UX-related logic (smart defaults / suggestions) will be handled in a separate issue

## Closes
Closes #21