### PR TITLE
Suggested Defaults API for Add Set

### DIFF
--- a/apps/api/src/modules/workouts/dto/get-set-defaults.query.dto.ts
+++ b/apps/api/src/modules/workouts/dto/get-set-defaults.query.dto.ts
@@ -1,0 +1,8 @@
+import { IsInt } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetSetDefaultsQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  dayExerciseId!: number;
+}

--- a/apps/api/src/modules/workouts/workouts.controller.ts
+++ b/apps/api/src/modules/workouts/workouts.controller.ts
@@ -6,10 +6,12 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import { WorkoutsService } from './workouts.service';
 import { StartWorkoutSessionDto } from './dto/start-workout-session.dto';
 import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
+import { GetSetDefaultsQueryDto } from './dto/get-set-defaults.query.dto';
 
 @Controller('workouts/sessions')
 export class WorkoutsController {
@@ -35,6 +37,14 @@ export class WorkoutsController {
     @Param('sessionId', ParseIntPipe) sessionId: number,
   ) {
     return this.workoutsService.findOneDetailed(sessionId);
+  }
+
+  @Get(':sessionId/sets/defaults')
+  getSetDefaults(
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+    @Query() query: GetSetDefaultsQueryDto,
+  ) {
+    return this.workoutsService.getSetDefaults(sessionId, query.dayExerciseId);
   }
 
   @Post(':sessionId/sets')

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -274,4 +274,158 @@ export class WorkoutsService {
       exercises,
     };
   }
+
+  async getSetDefaults(sessionId: number, dayExerciseId: number) {
+    const session = await this.getSessionOr404(sessionId);
+
+    // dayExercise חייב להיות מתוך אותו ProgramDay של הסשן
+    const de = await this.prisma.dayExercise.findFirst({
+      where: { id: dayExerciseId, programDayId: session.programDayId },
+      select: { id: true, exerciseId: true },
+    });
+
+    if (!de) {
+      throw new NotFoundException('Day exercise not found under session day');
+    }
+
+    const exerciseId = de.exerciseId;
+
+    // 1) suggested: "Top working set" מהאימון האחרון (הקודם) שבו התרגיל בוצע
+    const lastSessionWithExercise = await this.prisma.workoutSession.findFirst({
+      where: {
+        id: { not: sessionId },
+        sets: {
+          some: {
+            dayExercise: { exerciseId },
+          },
+        },
+      },
+      orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
+      select: { id: true, startedAt: true },
+    });
+
+    let suggested: any = null;
+
+    if (lastSessionWithExercise) {
+      const topSet = await this.prisma.workoutSet.findFirst({
+        where: {
+          sessionId: lastSessionWithExercise.id,
+          dayExercise: { exerciseId },
+        },
+        orderBy: [
+          { weight: 'desc' },
+          { reps: 'desc' },
+          { setNumber: 'desc' },
+          { id: 'desc' },
+        ],
+        select: { id: true, weight: true, reps: true },
+      });
+
+      if (topSet) {
+        suggested = {
+          weight: topSet.weight,
+          reps: topSet.reps,
+          source: 'LAST_SESSION_TOP_SET',
+          basedOn: {
+            sessionId: lastSessionWithExercise.id,
+            performedAt: lastSessionWithExercise.startedAt.toISOString(),
+            setId: topSet.id,
+            weight: topSet.weight,
+            reps: topSet.reps,
+          },
+        };
+      }
+    }
+
+    // 2) bestRecentE1rm: חלון 8 אימונים אחרונים שבהם התרגיל בוצע (ללא הסשן הנוכחי)
+    const windowSessions = await this.prisma.workoutSession.findMany({
+      where: {
+        id: { not: sessionId },
+        sets: { some: { dayExercise: { exerciseId } } },
+      },
+      orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
+      take: 8,
+      select: { id: true, startedAt: true },
+    });
+
+    let bestRecentE1rm: any = null;
+
+    if (windowSessions.length > 0) {
+      const sessionIds = windowSessions.map((s) => s.id);
+      const startedAtBySessionId = new Map(windowSessions.map((s) => [s.id, s.startedAt] as const));
+
+      const eligibleSets = await this.prisma.workoutSet.findMany({
+        where: {
+          sessionId: { in: sessionIds },
+          dayExercise: { exerciseId },
+          reps: { gte: 3, lte: 12 },
+          weight: { gt: 0 },
+        },
+        select: {
+          id: true,
+          sessionId: true,
+          reps: true,
+          weight: true,
+        },
+      });
+
+      const epley = (w: number, r: number) => w * (1 + r / 30);
+
+      if (eligibleSets.length > 0) {
+        let best = eligibleSets[0];
+        let bestVal = epley(best.weight, best.reps);
+
+        for (let i = 1; i < eligibleSets.length; i++) {
+          const cur = eligibleSets[i];
+          const curVal = epley(cur.weight, cur.reps);
+
+          const bestAt = startedAtBySessionId.get(best.sessionId) ?? new Date(0);
+          const curAt = startedAtBySessionId.get(cur.sessionId) ?? new Date(0);
+
+          const isBetter =
+            curVal > bestVal ||
+            (curVal === bestVal && cur.weight > best.weight) ||
+            (curVal === bestVal && cur.weight === best.weight && cur.reps > best.reps) ||
+            (curVal === bestVal &&
+              cur.weight === best.weight &&
+              cur.reps === best.reps &&
+              curAt > bestAt) ||
+            (curVal === bestVal &&
+              cur.weight === best.weight &&
+              cur.reps === best.reps &&
+              curAt.getTime() === bestAt.getTime() &&
+              cur.id > best.id);
+
+          if (isBetter) {
+            best = cur;
+            bestVal = curVal;
+          }
+        }
+
+        const performedAt = startedAtBySessionId.get(best.sessionId) ?? new Date(0);
+
+        bestRecentE1rm = {
+          windowSessions: 8,
+          formula: 'EPLEY',
+          repsFilter: { min: 3, max: 12 },
+          e1rm: Number(bestVal.toFixed(1)),
+          set: {
+            sessionId: best.sessionId,
+            performedAt: performedAt.toISOString(),
+            setId: best.id,
+            weight: best.weight,
+            reps: best.reps,
+          },
+        };
+      }
+    }
+
+    return {
+      sessionId,
+      dayExerciseId,
+      exerciseId,
+      suggested,
+      bestRecentE1rm,
+    };
+  }
 }


### PR DESCRIPTION
## What
Add a read-only API that provides smart defaults when adding a new workout set,
based on previous performance data for the same exercise.

## Why
This endpoint is required to support fast, low-friction workout logging
in a mobile-first UX, without disruptive popups or performance warnings.

It enables:
- Pre-filled weight/reps when adding a new set
- Quiet indication of recent best performance
- Separation between execution-time UX and post-workout analytics

## Endpoints
- GET /api/workouts/sessions/:sessionId/sets/defaults?dayExerciseId=number

## Features
- Suggested defaults (weight, reps) based on:
  - The top working set from the most recent prior session
  - Highest weight, tie-break by reps
- Best recent performance indicator:
  - Computed using estimated 1RM (Epley)
  - Rolling window of the last 8 sessions where the exercise was performed
  - Reps filter [3..12] to avoid warmups and endurance-only sets
- Current session data is fully excluded from all calculations
- Graceful handling of missing history (null defaults)

## Implementation Details
- Resolve exercise context via DayExercise (single source of truth)
- Suggested defaults:
  - Query most recent prior WorkoutSession containing the exercise
  - Select top working set by weight, reps, setNumber (deterministic)
- Best recent performance:
  - Query last 8 sessions where the exercise was performed
  - Compute e1RM in service layer using Epley formula
  - Deterministic tie-breakers (e1RM, weight, reps, date, id)
- No data persistence; endpoint is read-only
- No raw Prisma entities exposed directly

## How to Test
1. Complete a workout session with at least one set for an exercise
2. Start a new workout session that includes the same DayExercise
3. Call:
   GET /api/workouts/sessions/:sessionId/sets/defaults?dayExerciseId=...
4. Verify:
   - Suggested defaults come from the previous session only
   - Best recent e1RM reflects the correct set
   - Adding sets to the current session does not affect results
   - Invalid dayExerciseId returns an error

## Notes
- This PR does NOT modify addSet behavior
- No frontend integration is included
- No user ownership or authentication logic is introduced
- Free / ad-hoc workouts are intentionally not supported

## Closes
Closes #23