### PR TITLE
Scope workout sessions and analytics by user

### DIFF
--- a/apps/api/prisma/migrations/20260128102741_user_mvp/migration.sql
+++ b/apps/api/prisma/migrations/20260128102741_user_mvp/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `WorkoutSession` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "WorkoutSession" ADD COLUMN     "userId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WorkoutSession_userId_startedAt_idx" ON "WorkoutSession"("userId", "startedAt");
+
+-- AddForeignKey
+ALTER TABLE "WorkoutSession" ADD CONSTRAINT "WorkoutSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -7,6 +7,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  workoutSessions WorkoutSession[]
+}
+
 model Program {
   id              Int              @id @default(autoincrement())
   name            String
@@ -67,6 +75,9 @@ model WorkoutSession {
   programDay   ProgramDay @relation(fields: [programDayId], references: [id])
   programDayId Int
 
+  user User @relation(fields: [userId], references: [id])
+  userId Int
+
   startedAt DateTime  @default(now())
   endedAt   DateTime?
 
@@ -74,6 +85,8 @@ model WorkoutSession {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([userId, startedAt])
 }
 
 model WorkoutSet {

--- a/apps/api/src/common/current-user-id.decorator.ts
+++ b/apps/api/src/common/current-user-id.decorator.ts
@@ -1,0 +1,17 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUserId = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext): number => {
+    const req = ctx.switchToHttp().getRequest();
+
+    const raw = req.headers['x-user-id'];
+    const parsed =
+      typeof raw === 'string'
+        ? Number(raw)
+        : Array.isArray(raw)
+          ? Number(raw[0])
+          : NaN;
+
+    return Number.isFinite(parsed) ? parsed : 1; // fallback for local dev
+  },
+);

--- a/apps/api/src/modules/workouts/workouts.controller.ts
+++ b/apps/api/src/modules/workouts/workouts.controller.ts
@@ -12,56 +12,57 @@ import { WorkoutsService } from './workouts.service';
 import { StartWorkoutSessionDto } from './dto/start-workout-session.dto';
 import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
 import { GetSetDefaultsQueryDto } from './dto/get-set-defaults.query.dto';
+import { CurrentUserId } from '../../common/current-user-id.decorator';
 
 @Controller('workouts/sessions')
 export class WorkoutsController {
   constructor(private readonly workoutsService: WorkoutsService) { }
 
   @Get()
-  findAll() {
-    return this.workoutsService.findAll();
+  findAll(@CurrentUserId() userId: number) {
+    return this.workoutsService.findAll(userId);
   }
 
   @Post('start')
-  start(@Body() dto: StartWorkoutSessionDto) {
-    return this.workoutsService.start(dto);
+  start(@CurrentUserId() userId: number, @Body() dto: StartWorkoutSessionDto) {
+    return this.workoutsService.start(userId, dto);
   }
 
   @Get(':sessionId')
-  getSession(@Param('sessionId', ParseIntPipe) sessionId: number) {
-    return this.workoutsService.getSession(sessionId);
+  getSession(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+    return this.workoutsService.getSession(userId, sessionId);
   }
 
   @Get(':sessionId/details')
-  findOneDetailed(
+  findOneDetailed(@CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
   ) {
-    return this.workoutsService.findOneDetailed(sessionId);
+    return this.workoutsService.findOneDetailed(userId, sessionId);
   }
 
   @Get(':sessionId/sets/defaults')
-  getSetDefaults(
+  getSetDefaults(@CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Query() query: GetSetDefaultsQueryDto,
   ) {
-    return this.workoutsService.getSetDefaults(sessionId, query.dayExerciseId);
+    return this.workoutsService.getSetDefaults(userId, sessionId, query.dayExerciseId);
   }
 
   @Post(':sessionId/sets')
-  addSet(
+  addSet(@CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Body() dto: CreateWorkoutSetDto,
   ) {
-    return this.workoutsService.addSet(sessionId, dto);
+    return this.workoutsService.addSet(userId, sessionId, dto);
   }
 
   @Patch(':sessionId/finish')
-  finish(@Param('sessionId', ParseIntPipe) sessionId: number) {
-    return this.workoutsService.finish(sessionId);
+  finish(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+    return this.workoutsService.finish(userId, sessionId);
   }
 
   @Get(':sessionId/summary')
-  getSummary(@Param('sessionId', ParseIntPipe) sessionId: number) {
-    return this.workoutsService.getSummary(sessionId);
+  getSummary(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+    return this.workoutsService.getSummary(userId, sessionId);
   }
 }

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -10,7 +10,7 @@ import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
 
 @Injectable()
 export class WorkoutsService {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(private readonly prisma: PrismaService) {}
 
   private async ensureProgramDayOwnership(programId: number, programDayId: number) {
     const day = await this.prisma.programDay.findFirst({
@@ -20,31 +20,40 @@ export class WorkoutsService {
     if (!day) throw new NotFoundException('Program day not found under program');
   }
 
-  private async getSessionOr404(sessionId: number) {
-    const session = await this.prisma.workoutSession.findUnique({
-      where: { id: sessionId },
-      select: { id: true, programId: true, programDayId: true, endedAt: true },
+  private async getSessionOr404(userId: number, sessionId: number) {
+    const session = await this.prisma.workoutSession.findFirst({
+      where: { id: sessionId, userId },
+      select: {
+        id: true,
+        userId: true,
+        programId: true,
+        programDayId: true,
+        endedAt: true,
+        startedAt: true,
+      },
     });
     if (!session) throw new NotFoundException('Workout session not found');
     return session;
   }
 
-  async start(dto: StartWorkoutSessionDto) {
+  async start(userId: number, dto: StartWorkoutSessionDto) {
     await this.ensureProgramDayOwnership(dto.programId, dto.programDayId);
 
     return this.prisma.workoutSession.create({
       data: {
+        userId,
         programId: dto.programId,
         programDayId: dto.programDayId,
       },
     });
   }
 
-  async getSession(sessionId: number) {
-    await this.getSessionOr404(sessionId);
+  async getSession(userId: number, sessionId: number) {
+    await this.getSessionOr404(userId, sessionId);
 
-    return this.prisma.workoutSession.findUnique({
-      where: { id: sessionId },
+    // IMPORTANT: findUnique({id}) can't include userId filter, so use findFirst
+    return this.prisma.workoutSession.findFirst({
+      where: { id: sessionId, userId },
       include: {
         sets: {
           orderBy: [{ dayExerciseId: 'asc' }, { setNumber: 'asc' }],
@@ -60,8 +69,8 @@ export class WorkoutsService {
     });
   }
 
-  async addSet(sessionId: number, dto: CreateWorkoutSetDto): Promise<WorkoutSet> {
-    const session = await this.getSessionOr404(sessionId);
+  async addSet(userId: number, sessionId: number, dto: CreateWorkoutSetDto): Promise<WorkoutSet> {
+    const session = await this.getSessionOr404(userId, sessionId);
     if (session.endedAt) throw new ConflictException('Workout session already finished');
 
     const de = await this.prisma.dayExercise.findFirst({
@@ -88,8 +97,8 @@ export class WorkoutsService {
     }
   }
 
-  async finish(sessionId: number) {
-    await this.getSessionOr404(sessionId);
+  async finish(userId: number, sessionId: number) {
+    await this.getSessionOr404(userId, sessionId);
 
     return this.prisma.workoutSession.update({
       where: { id: sessionId },
@@ -97,8 +106,9 @@ export class WorkoutsService {
     });
   }
 
-  async findAll() {
+  async findAll(userId: number) {
     return this.prisma.workoutSession.findMany({
+      where: { userId },
       orderBy: { startedAt: 'desc' },
       select: {
         id: true,
@@ -111,19 +121,19 @@ export class WorkoutsService {
     });
   }
 
-  async findOneDetailed(sessionId: number) {
-    const session = await this.prisma.workoutSession.findUnique({
-      where: { id: sessionId },
+  async findOneDetailed(userId: number, sessionId: number) {
+    // enforce ownership
+    await this.getSessionOr404(userId, sessionId);
+
+    const session = await this.prisma.workoutSession.findFirst({
+      where: { id: sessionId, userId },
       include: {
         program: { select: { id: true, name: true, type: true } },
         programDay: { select: { id: true, name: true, order: true } },
       },
     });
 
-
-    if (!session) {
-      throw new NotFoundException('Workout session not found');
-    }
+    if (!session) throw new NotFoundException('Workout session not found');
 
     const plannedExercises = await this.prisma.dayExercise.findMany({
       where: { programDayId: session.programDayId },
@@ -171,10 +181,12 @@ export class WorkoutsService {
     };
   }
 
-  async getSummary(sessionId: number) {
-    // 1) session + קונטקסט בסיסי
-    const session = await this.prisma.workoutSession.findUnique({
-      where: { id: sessionId },
+  async getSummary(userId: number, sessionId: number) {
+    // enforce ownership
+    await this.getSessionOr404(userId, sessionId);
+
+    const session = await this.prisma.workoutSession.findFirst({
+      where: { id: sessionId, userId },
       select: {
         id: true,
         startedAt: true,
@@ -184,7 +196,6 @@ export class WorkoutsService {
 
     if (!session) throw new NotFoundException('Workout session not found');
 
-    // 2) כל הסטים עם join עד Exercise (בלי N+1)
     const sets = await this.prisma.workoutSet.findMany({
       where: { sessionId },
       orderBy: [{ dayExerciseId: 'asc' }, { setNumber: 'asc' }],
@@ -202,16 +213,15 @@ export class WorkoutsService {
       },
     });
 
-    // durationSeconds לפי דרישה: רק אם הסתיים
     const durationSeconds =
-      session.endedAt ? Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000) : null;
+      session.endedAt
+        ? Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000)
+        : null;
 
-    // totals
     let totalSets = 0;
     let totalReps = 0;
     let totalVolume = 0;
 
-    // per exercise aggregation
     type TopSet = { weight: number; reps: number };
     type ExerciseAgg = {
       exerciseId: number;
@@ -245,7 +255,6 @@ export class WorkoutsService {
       curr.repsTotal += s.reps;
       curr.volume += volume;
 
-      // topSet: הכי גבוה weight, ואם תיקו אז הכי גבוה reps
       if (
         curr.topSet === null ||
         s.weight > curr.topSet.weight ||
@@ -257,8 +266,6 @@ export class WorkoutsService {
       byExercise.set(ex.id, curr);
     }
 
-    // יציבות: נמיין לפי שם/או לפי exerciseId (תבחר אחד).
-    // הכי דטרמיניסטי: exerciseId asc
     const exercises = Array.from(byExercise.values()).sort((a, b) => a.exerciseId - b.exerciseId);
 
     return {
@@ -275,10 +282,9 @@ export class WorkoutsService {
     };
   }
 
-  async getSetDefaults(sessionId: number, dayExerciseId: number) {
-    const session = await this.getSessionOr404(sessionId);
+  async getSetDefaults(userId: number, sessionId: number, dayExerciseId: number) {
+    const session = await this.getSessionOr404(userId, sessionId);
 
-    // dayExercise חייב להיות מתוך אותו ProgramDay של הסשן
     const de = await this.prisma.dayExercise.findFirst({
       where: { id: dayExerciseId, programDayId: session.programDayId },
       select: { id: true, exerciseId: true },
@@ -290,9 +296,10 @@ export class WorkoutsService {
 
     const exerciseId = de.exerciseId;
 
-    // 1) suggested: "Top working set" מהאימון האחרון (הקודם) שבו התרגיל בוצע
+    // 1) Suggested: top working set from most recent prior session FOR THIS USER
     const lastSessionWithExercise = await this.prisma.workoutSession.findFirst({
       where: {
+        userId,
         id: { not: sessionId },
         sets: {
           some: {
@@ -337,9 +344,10 @@ export class WorkoutsService {
       }
     }
 
-    // 2) bestRecentE1rm: חלון 8 אימונים אחרונים שבהם התרגיל בוצע (ללא הסשן הנוכחי)
+    // 2) BestRecentE1rm: last 8 sessions where exercise performed FOR THIS USER
     const windowSessions = await this.prisma.workoutSession.findMany({
       where: {
+        userId,
         id: { not: sessionId },
         sets: { some: { dayExercise: { exerciseId } } },
       },


### PR DESCRIPTION
## What
Introduce a minimal User model and enforce user ownership on workout sessions
and all workout-related APIs.

## Why
Previously, all workout data was effectively global.

This change is required to:
- Enforce data isolation between users
- Make workout history, summaries and defaults user-specific
- Prepare the system for future authentication and frontend work
- Prevent cross-user access to workout sessions

This PR intentionally introduces the smallest possible user layer (MVP),
without full authentication or authorization.

## Endpoints
- POST /api/workouts/sessions/start
- GET /api/workouts/sessions
- GET /api/workouts/sessions/:sessionId
- GET /api/workouts/sessions/:sessionId/details
- POST /api/workouts/sessions/:sessionId/sets
- PATCH /api/workouts/sessions/:sessionId/finish
- GET /api/workouts/sessions/:sessionId/summary
- GET /api/workouts/sessions/:sessionId/sets/defaults

(All endpoints are now user-scoped.)

## Features
- New User model
- WorkoutSession is now owned by exactly one User
- All workout-related queries are filtered by userId
- Ownership is enforced consistently via a single helper (getSessionOr404)
- Temporary user identification via X-User-Id header (MVP)
- Defaults, summaries and history calculations are fully user-isolated

## Implementation Details
- Added User model to the schema
- Added required userId field to WorkoutSession
- Introduced CurrentUserId decorator (X-User-Id with local fallback)
- Updated all WorkoutsService methods to accept userId
- Replaced unsafe findUnique calls with findFirst where ownership is required
- Defaults endpoint filters historical data by userId
- No authentication or authorization framework introduced

## How to Test
1. Create two users (e.g. userId = 1 and userId = 2)
2. Start a workout session with:
   X-User-Id: 1
3. Verify the session is listed only for user 1
4. Attempt to access the same session with:
   X-User-Id: 2
5. Verify a 404 is returned
6. Verify defaults and summaries only consider the owning user’s data

## Notes
- This PR intentionally keeps the User model minimal
- Program and Exercise ownership are handled in a separate issue
- Authentication and authorization will be added later
- No frontend changes are included

## Closes
Closes #25