### PR TITLE
Enforce user ownership across programs, days and workout sessions

### DIFF
--- a/apps/api/prisma/migrations/20260128112353_program_user_ownership/migration.sql
+++ b/apps/api/prisma/migrations/20260128112353_program_user_ownership/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `Program` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Program" ADD COLUMN     "userId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Program" ADD CONSTRAINT "Program_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   updatedAt DateTime @updatedAt
 
   workoutSessions WorkoutSession[]
+  programs Program[]
 }
 
 model Program {
@@ -24,6 +25,9 @@ model Program {
   type            ProgramType
   days            ProgramDay[]
   workoutSessions WorkoutSession[]
+
+  user User @relation(fields: [userId], references: [id])
+  userId Int
 }
 
 model ProgramDay {

--- a/apps/api/src/common/current-user-id.decorator.ts
+++ b/apps/api/src/common/current-user-id.decorator.ts
@@ -1,17 +1,19 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 
-export const CurrentUserId = createParamDecorator(
-  (_: unknown, ctx: ExecutionContext): number => {
-    const req = ctx.switchToHttp().getRequest();
+export const CurrentUserId = createParamDecorator((_: unknown, ctx: ExecutionContext): number => {
+  const req = ctx.switchToHttp().getRequest();
+  const raw = req.headers['x-user-id'];
 
-    const raw = req.headers['x-user-id'];
-    const parsed =
-      typeof raw === 'string'
-        ? Number(raw)
-        : Array.isArray(raw)
-          ? Number(raw[0])
-          : NaN;
+  const parsed =
+    typeof raw === 'string'
+      ? Number(raw)
+      : Array.isArray(raw)
+        ? Number(raw[0])
+        : NaN;
 
-    return Number.isFinite(parsed) ? parsed : 1; // fallback for local dev
-  },
-);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new UnauthorizedException('Missing/invalid user identity');
+  }
+
+  return parsed;
+});

--- a/apps/api/src/modules/day-exercises/day-exercises.controller.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.controller.ts
@@ -8,6 +8,7 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
+import { CurrentUserId } from '../../common/current-user-id.decorator';
 import { DayExercisesService } from './day-exercises.service';
 import { CreateDayExerciseDto } from './dto/create-day-exercise.dto';
 import { UpdateDayExerciseDto } from './dto/update-day-exercise.dto';
@@ -18,38 +19,52 @@ export class DayExercisesController {
 
   @Post()
   create(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
     @Body() dto: CreateDayExerciseDto,
   ) {
-    return this.dayExercisesService.create(programId, dayId, dto);
+    return this.dayExercisesService.create(userId, programId, dayId, dto);
   }
 
   @Get()
   findAll(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
   ) {
-    return this.dayExercisesService.findAll(programId, dayId);
+    return this.dayExercisesService.findAll(userId, programId, dayId);
+  }
+
+  @Get(':dayExerciseId')
+  findOne(
+    @CurrentUserId() userId: number,
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+    @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
+  ) {
+    return this.dayExercisesService.findOne(userId, programId, dayId, dayExerciseId);
   }
 
   @Patch(':dayExerciseId')
   update(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
     @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
     @Body() dto: UpdateDayExerciseDto,
   ) {
-    return this.dayExercisesService.update(programId, dayId, dayExerciseId, dto);
+    return this.dayExercisesService.update(userId, programId, dayId, dayExerciseId, dto);
   }
 
   @Delete(':dayExerciseId')
   async remove(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
     @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
   ) {
-    await this.dayExercisesService.remove(programId, dayId, dayExerciseId);
+    await this.dayExercisesService.remove(userId, programId, dayId, dayExerciseId);
     return { ok: true };
   }
 }

--- a/apps/api/src/modules/day-exercises/day-exercises.service.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.service.ts
@@ -19,38 +19,41 @@ export class DayExercisesService {
     }
   }
 
-  private async ensureProgramExists(programId: number) {
-    const program = await this.prisma.program.findUnique({
-      where: { id: programId },
-      select: { id: true },
-    });
-    if (!program) throw new NotFoundException('Program not found');
-  }
-
-  private async ensureDayExists(programId: number, dayId: number) {
-    await this.ensureProgramExists(programId);
-
+  private async ensureDayOwnership(userId: number, programId: number, dayId: number) {
+    // מאמתים גם programId וגם dayId וגם שהכל שייך ל-user
     const day = await this.prisma.programDay.findFirst({
-      where: { id: dayId, programId },
+      where: {
+        id: dayId,
+        programId,
+        program: { userId },
+      },
       select: { id: true },
     });
 
     if (!day) throw new NotFoundException('Program day not found');
   }
 
+  private async ensureExerciseVisibleToUser(userId: number, exerciseId: number) {
+    // בינתיים: אם עוד לא הוספת exercise.userId, תשאיר findUnique רגיל.
+    // אחרי שתוסיף userId nullable, מחליפים את זה ל:
+    // where: { id: exerciseId, OR: [{ userId: null }, { userId }] }
+    const ex = await this.prisma.exercise.findUnique({
+      where: { id: exerciseId },
+      select: { id: true },
+    });
+    if (!ex) throw new NotFoundException('Exercise not found');
+  }
+
   async create(
+    userId: number,
     programId: number,
     dayId: number,
     dto: CreateDayExerciseDto,
   ): Promise<DayExercise> {
-    await this.ensureDayExists(programId, dayId);
+    await this.ensureDayOwnership(userId, programId, dayId);
     this.validateRepRange(dto.minReps, dto.maxReps);
 
-    const exercise = await this.prisma.exercise.findUnique({
-      where: { id: dto.exerciseId },
-      select: { id: true },
-    });
-    if (!exercise) throw new NotFoundException('Exercise not found');
+    await this.ensureExerciseVisibleToUser(userId, dto.exerciseId);
 
     try {
       return await this.prisma.dayExercise.create({
@@ -71,43 +74,77 @@ export class DayExercisesService {
     }
   }
 
-  async findAll(programId: number, dayId: number): Promise<DayExercise[]> {
-    await this.ensureDayExists(programId, dayId);
+  async findAll(userId: number, programId: number, dayId: number): Promise<DayExercise[]> {
+    await this.ensureDayOwnership(userId, programId, dayId);
 
     return this.prisma.dayExercise.findMany({
-      where: { programDayId: dayId },
+      where: {
+        programDayId: dayId,
+        programDay: { program: { userId } },
+      },
       orderBy: { order: 'asc' },
     });
   }
 
+  async findOne(
+    userId: number,
+    programId: number,
+    dayId: number,
+    dayExerciseId: number,
+  ): Promise<DayExercise> {
+    await this.ensureDayOwnership(userId, programId, dayId);
+
+    const de = await this.prisma.dayExercise.findFirst({
+      where: {
+        id: dayExerciseId,
+        programDayId: dayId,
+        programDay: { program: { userId } },
+      },
+    });
+
+    if (!de) throw new NotFoundException('Day exercise not found');
+    return de;
+  }
+
   async update(
+    userId: number,
     programId: number,
     dayId: number,
     dayExerciseId: number,
     dto: UpdateDayExerciseDto,
   ): Promise<DayExercise> {
-    await this.ensureDayExists(programId, dayId);
-
+    await this.ensureDayOwnership(userId, programId, dayId);
     this.validateRepRange(dto.minReps, dto.maxReps);
 
-    const existing = await this.prisma.dayExercise.findFirst({
-      where: { id: dayExerciseId, programDayId: dayId },
-    });
-    if (!existing) throw new NotFoundException('Day exercise not found');
-
-    if (dto.exerciseId !== undefined) {
-      const exercise = await this.prisma.exercise.findUnique({
-        where: { id: dto.exerciseId },
-        select: { id: true },
-      });
-      if (!exercise) throw new NotFoundException('Exercise not found');
-    }
+    const data: Prisma.DayExerciseUpdateManyMutationInput = {
+      ...(dto.order !== undefined ? { order: dto.order } : {}),
+      ...(dto.targetSets !== undefined ? { targetSets: dto.targetSets } : {}),
+      ...(dto.minReps !== undefined ? { minReps: dto.minReps } : {}),
+      ...(dto.maxReps !== undefined ? { maxReps: dto.maxReps } : {}),
+    };
 
     try {
-      return await this.prisma.dayExercise.update({
-        where: { id: dayExerciseId },
-        data: dto,
+      const res = await this.prisma.dayExercise.updateMany({
+        where: {
+          id: dayExerciseId,
+          programDayId: dayId,
+          programDay: { program: { userId } },
+        },
+        data,
       });
+
+      if (res.count === 0) throw new NotFoundException('Day exercise not found');
+
+      const updated = await this.prisma.dayExercise.findFirst({
+        where: {
+          id: dayExerciseId,
+          programDayId: dayId,
+          programDay: { program: { userId } },
+        },
+      });
+
+      if (!updated) throw new NotFoundException('Day exercise not found');
+      return updated;
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         throw new ConflictException('Exercise order already exists for this day');
@@ -116,15 +153,22 @@ export class DayExercisesService {
     }
   }
 
-  async remove(programId: number, dayId: number, dayExerciseId: number): Promise<void> {
-    await this.ensureDayExists(programId, dayId);
+  async remove(
+    userId: number,
+    programId: number,
+    dayId: number,
+    dayExerciseId: number,
+  ): Promise<void> {
+    await this.ensureDayOwnership(userId, programId, dayId);
 
-    const existing = await this.prisma.dayExercise.findFirst({
-      where: { id: dayExerciseId, programDayId: dayId },
-      select: { id: true },
+    const res = await this.prisma.dayExercise.deleteMany({
+      where: {
+        id: dayExerciseId,
+        programDayId: dayId,
+        programDay: { program: { userId } },
+      },
     });
-    if (!existing) throw new NotFoundException('Day exercise not found');
 
-    await this.prisma.dayExercise.delete({ where: { id: dayExerciseId } });
+    if (res.count === 0) throw new NotFoundException('Day exercise not found');
   }
 }

--- a/apps/api/src/modules/day-exercises/dto/update-day-exercise.dto.ts
+++ b/apps/api/src/modules/day-exercises/dto/update-day-exercise.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType, OmitType } from '@nestjs/mapped-types';
 import { CreateDayExerciseDto } from './create-day-exercise.dto';
 
-export class UpdateDayExerciseDto extends PartialType(CreateDayExerciseDto) {}
+export class UpdateDayExerciseDto extends PartialType(
+  OmitType(CreateDayExerciseDto, ['exerciseId'] as const),
+) {}

--- a/apps/api/src/modules/program-days/program-days.controller.ts
+++ b/apps/api/src/modules/program-days/program-days.controller.ts
@@ -11,6 +11,7 @@ import {
 import { ProgramDaysService } from './program-days.service';
 import { CreateProgramDayDto } from './dto/create-program-day.dto';
 import { UpdateProgramDayDto } from './dto/update-program-day.dto';
+import { CurrentUserId } from '../../common/current-user-id.decorator';
 
 @Controller('programs/:programId/days')
 export class ProgramDaysController {
@@ -18,40 +19,47 @@ export class ProgramDaysController {
 
   @Post()
   create(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Body() dto: CreateProgramDayDto,
   ) {
-    return this.programDaysService.create(programId, dto);
+    return this.programDaysService.create(userId, programId, dto);
   }
 
   @Get()
-  findAll(@Param('programId', ParseIntPipe) programId: number) {
-    return this.programDaysService.findAll(programId);
+  findAll(
+    @CurrentUserId() userId: number,
+    @Param('programId', ParseIntPipe) programId: number,
+  ) {
+    return this.programDaysService.findAll(userId, programId);
   }
 
   @Get(':dayId')
   findOne(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
   ) {
-    return this.programDaysService.findOne(programId, dayId);
+    return this.programDaysService.findOne(userId, programId, dayId);
   }
 
   @Patch(':dayId')
   update(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
     @Body() dto: UpdateProgramDayDto,
   ) {
-    return this.programDaysService.update(programId, dayId, dto);
+    return this.programDaysService.update(userId, programId, dayId, dto);
   }
 
   @Delete(':dayId')
   async remove(
+    @CurrentUserId() userId: number,
     @Param('programId', ParseIntPipe) programId: number,
     @Param('dayId', ParseIntPipe) dayId: number,
   ) {
-    await this.programDaysService.remove(programId, dayId);
+    await this.programDaysService.remove(userId, programId, dayId);
     return { ok: true };
   }
 }

--- a/apps/api/src/modules/program-days/program-days.service.ts
+++ b/apps/api/src/modules/program-days/program-days.service.ts
@@ -1,8 +1,4 @@
-import {
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma, ProgramDay } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateProgramDayDto } from './dto/create-program-day.dto';
@@ -12,16 +8,16 @@ import { UpdateProgramDayDto } from './dto/update-program-day.dto';
 export class ProgramDaysService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private async ensureProgramExists(programId: number): Promise<void> {
-    const exists = await this.prisma.program.findUnique({
-      where: { id: programId },
+  private async ensureProgramOwnership(userId: number, programId: number): Promise<void> {
+    const program = await this.prisma.program.findFirst({
+      where: { id: programId, userId },
       select: { id: true },
     });
-    if (!exists) throw new NotFoundException('Program not found');
+    if (!program) throw new NotFoundException('Program not found');
   }
 
-  async create(programId: number, dto: CreateProgramDayDto): Promise<ProgramDay> {
-    await this.ensureProgramExists(programId);
+  async create(userId: number, programId: number, dto: CreateProgramDayDto): Promise<ProgramDay> {
+    await this.ensureProgramOwnership(userId, programId);
 
     try {
       return await this.prisma.programDay.create({
@@ -40,20 +36,28 @@ export class ProgramDaysService {
     }
   }
 
-  async findAll(programId: number): Promise<ProgramDay[]> {
-    await this.ensureProgramExists(programId);
+  async findAll(userId: number, programId: number): Promise<ProgramDay[]> {
+    // validate ownership and avoid leaking whether programId exists
+    await this.ensureProgramOwnership(userId, programId);
 
     return this.prisma.programDay.findMany({
-      where: { programId },
+      where: {
+        programId,
+        program: { userId },
+      },
       orderBy: { order: 'asc' },
     });
   }
 
-  async findOne(programId: number, dayId: number): Promise<ProgramDay> {
-    await this.ensureProgramExists(programId);
+  async findOne(userId: number, programId: number, dayId: number): Promise<ProgramDay> {
+    await this.ensureProgramOwnership(userId, programId);
 
     const day = await this.prisma.programDay.findFirst({
-      where: { id: dayId, programId },
+      where: {
+        id: dayId,
+        programId,
+        program: { userId },
+      },
     });
 
     if (!day) throw new NotFoundException('Program day not found');
@@ -61,20 +65,42 @@ export class ProgramDaysService {
   }
 
   async update(
+    userId: number,
     programId: number,
     dayId: number,
     dto: UpdateProgramDayDto,
   ): Promise<ProgramDay> {
-    await this.ensureProgramExists(programId);
+    await this.ensureProgramOwnership(userId, programId);
 
-    // Ensure ownership
-    await this.findOne(programId, dayId);
+    // whitelist (avoid future over-posting)
+    const data: Prisma.ProgramDayUpdateManyMutationInput = {
+      ...(dto.name !== undefined ? { name: dto.name } : {}),
+      ...(dto.order !== undefined ? { order: dto.order } : {}),
+    };
 
     try {
-      return await this.prisma.programDay.update({
-        where: { id: dayId },
-        data: dto,
+      const res = await this.prisma.programDay.updateMany({
+        where: {
+          id: dayId,
+          programId,
+          program: { userId },
+        },
+        data,
       });
+
+      if (res.count === 0) throw new NotFoundException('Program day not found');
+
+      // return updated row
+      const updated = await this.prisma.programDay.findFirst({
+        where: {
+          id: dayId,
+          programId,
+          program: { userId },
+        },
+      });
+
+      if (!updated) throw new NotFoundException('Program day not found');
+      return updated;
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         throw new ConflictException('Day order already exists for this program');
@@ -83,12 +109,17 @@ export class ProgramDaysService {
     }
   }
 
-  async remove(programId: number, dayId: number): Promise<void> {
-    await this.ensureProgramExists(programId);
+  async remove(userId: number, programId: number, dayId: number): Promise<void> {
+    await this.ensureProgramOwnership(userId, programId);
 
-    // Ensure ownership
-    await this.findOne(programId, dayId);
+    const res = await this.prisma.programDay.deleteMany({
+      where: {
+        id: dayId,
+        programId,
+        program: { userId },
+      },
+    });
 
-    await this.prisma.programDay.delete({ where: { id: dayId } });
+    if (res.count === 0) throw new NotFoundException('Program day not found');
   }
 }

--- a/apps/api/src/modules/programs/dto/create-program.dto.ts
+++ b/apps/api/src/modules/programs/dto/create-program.dto.ts
@@ -1,5 +1,5 @@
 import { ProgramType } from '@prisma/client';
-import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsNotEmpty, IsOptional, IsString, IsBoolean } from 'class-validator';
 
 export class CreateProgramDto {
   @IsString()
@@ -9,4 +9,8 @@ export class CreateProgramDto {
   @IsString()
   @IsIn(['AB', 'PPL', 'FULL_BODY', 'CUSTOM'])
   type!: ProgramType;
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
 }

--- a/apps/api/src/modules/programs/programs.controller.ts
+++ b/apps/api/src/modules/programs/programs.controller.ts
@@ -11,42 +11,43 @@ import {
 import { ProgramsService } from './programs.service';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { UpdateProgramDto } from './dto/update-program.dto';
+import { CurrentUserId } from '../../common/current-user-id.decorator';
 
 @Controller('programs')
 export class ProgramsController {
   constructor(private readonly programsService: ProgramsService) { }
 
   @Post()
-  create(@Body() dto: CreateProgramDto) {
-    return this.programsService.create(dto);
+  create(@CurrentUserId() userId: number, @Body() dto: CreateProgramDto) {
+    return this.programsService.create(userId, dto);
   }
 
   @Get()
-  findAll() {
-    return this.programsService.findAll();
+  findAll(@CurrentUserId() userId: number,) {
+    return this.programsService.findAll(userId);
   }
 
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number) {
-    return this.programsService.findOne(id);
+  findOne(@CurrentUserId() userId: number, @Param('id', ParseIntPipe) id: number) {
+    return this.programsService.findOne(userId, id);
   }
 
   @Get(':id/detailed')
-  findOneDetailed(@Param('id', ParseIntPipe) id: number) {
-    return this.programsService.findOneDetailed(id);
+  findOneDetailed(@CurrentUserId() userId: number, @Param('id', ParseIntPipe) id: number) {
+    return this.programsService.findOneDetailed(userId, id);
   }
 
   @Patch(':id')
-  update(
+  update(@CurrentUserId() userId: number,
     @Param('id', ParseIntPipe) id: number,
     @Body() dto: UpdateProgramDto,
   ) {
-    return this.programsService.update(id, dto);
+    return this.programsService.update(userId, id, dto);
   }
 
   @Delete(':id')
-  async remove(@Param('id', ParseIntPipe) id: number) {
-    await this.programsService.remove(id);
+  async remove(@CurrentUserId() userId: number, @Param('id', ParseIntPipe) id: number) {
+    await this.programsService.remove(userId, id);
     return { ok: true };
   }
 }

--- a/apps/api/src/modules/programs/programs.service.ts
+++ b/apps/api/src/modules/programs/programs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma, Program } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { UpdateProgramDto } from './dto/update-program.dto';
@@ -8,67 +8,100 @@ import { UpdateProgramDto } from './dto/update-program.dto';
 export class ProgramsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(dto: CreateProgramDto): Promise<Program> {
-    return this.prisma.program.create({ data: dto });
-  }
-
-  async findAll(): Promise<Program[]> {
-    return this.prisma.program.findMany({
-      orderBy: { createdAt: 'desc' },
+  async create(userId: number, dto: CreateProgramDto) {
+    return this.prisma.program.create({
+      data: {
+        userId,
+        name: dto.name,
+        type: dto.type,
+        isActive: dto.isActive ?? false,
+      },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        isActive: true,
+        createdAt: true,
+      },
     });
   }
 
-  async findOne(id: number): Promise<Program> {
-    const program = await this.prisma.program.findUnique({ where: { id } });
+  async findAll(userId: number) {
+    return this.prisma.program.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, name: true, type: true, isActive: true },
+    });
+  }
+
+  async findOne(userId: number, id: number) {
+    const program = await this.prisma.program.findFirst({
+      where: { id, userId },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        isActive: true,
+        days: {
+          orderBy: { order: 'asc' },
+          select: { id: true, name: true, order: true },
+        },
+      },
+    });
+
     if (!program) throw new NotFoundException('Program not found');
     return program;
   }
 
-  async update(id: number, dto: UpdateProgramDto): Promise<Program> {
-    try {
-      return await this.prisma.program.update({
-        where: { id },
-        data: dto,
-      });
-    } catch (e) {
-      // Prisma throws P2025 when record not found on update/delete
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
-        throw new NotFoundException('Program not found');
-      }
-      throw e;
-    }
-  }
-
-  async remove(id: number): Promise<void> {
-    try {
-      await this.prisma.program.delete({ where: { id } });
-    } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
-        throw new NotFoundException('Program not found');
-      }
-      throw e;
-    }
-  }
-
-  async findOneDetailed(id: number) {
-  const program = await this.prisma.program.findUnique({
-    where: { id },
-    include: {
-      days: {
-        orderBy: { order: 'asc' },
-        include: {
-          exercises: {
-            orderBy: { order: 'asc' },
-            include: {
-              exercise: { select: { id: true, name: true } },
+  async findOneDetailed(userId: number, id: number) {
+    const program = await this.prisma.program.findFirst({
+      where: { id, userId },
+      include: {
+        days: {
+          orderBy: { order: 'asc' },
+          include: {
+            exercises: {
+              orderBy: { order: 'asc' },
+              include: {
+                exercise: { select: { id: true, name: true } },
+              },
             },
           },
         },
       },
-    },
-  });
+    });
 
-  if (!program) throw new NotFoundException('Program not found');
-  return program;
-}
+    if (!program) throw new NotFoundException('Program not found');
+    return program;
+  }
+
+  async update(userId: number, id: number, dto: UpdateProgramDto) {
+    // whitelist only (never allow userId ownership changes)
+    const data: Prisma.ProgramUpdateManyMutationInput = {
+      ...(dto.name !== undefined ? { name: dto.name } : {}),
+      ...(dto.type !== undefined ? { type: dto.type } : {}),
+      ...(dto.isActive !== undefined ? { isActive: dto.isActive } : {}),
+    };
+
+    const res = await this.prisma.program.updateMany({
+      where: { id, userId },
+      data,
+    });
+
+    if (res.count === 0) throw new NotFoundException('Program not found');
+
+    // return a clean read shape (avoid leaking raw entity if you prefer)
+    return this.prisma.program.findFirst({
+      where: { id, userId },
+      select: { id: true, name: true, type: true, isActive: true, createdAt: true, updatedAt: true },
+    });
+  }
+
+  async remove(userId: number, id: number): Promise<void> {
+    const res = await this.prisma.program.deleteMany({
+      where: { id, userId },
+    });
+
+    if (res.count === 0) throw new NotFoundException('Program not found');
+  }
 }

--- a/apps/api/src/modules/workouts/workouts.controller.ts
+++ b/apps/api/src/modules/workouts/workouts.controller.ts
@@ -4,7 +4,6 @@ import {
   Get,
   Param,
   ParseIntPipe,
-  Patch,
   Post,
   Query,
 } from '@nestjs/common';
@@ -16,7 +15,7 @@ import { CurrentUserId } from '../../common/current-user-id.decorator';
 
 @Controller('workouts/sessions')
 export class WorkoutsController {
-  constructor(private readonly workoutsService: WorkoutsService) { }
+  constructor(private readonly workoutsService: WorkoutsService) {}
 
   @Get()
   findAll(@CurrentUserId() userId: number) {
@@ -29,19 +28,24 @@ export class WorkoutsController {
   }
 
   @Get(':sessionId')
-  getSession(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+  getSession(
+    @CurrentUserId() userId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
     return this.workoutsService.getSession(userId, sessionId);
   }
 
   @Get(':sessionId/details')
-  findOneDetailed(@CurrentUserId() userId: number,
+  findOneDetailed(
+    @CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
   ) {
     return this.workoutsService.findOneDetailed(userId, sessionId);
   }
 
   @Get(':sessionId/sets/defaults')
-  getSetDefaults(@CurrentUserId() userId: number,
+  getSetDefaults(
+    @CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Query() query: GetSetDefaultsQueryDto,
   ) {
@@ -49,20 +53,28 @@ export class WorkoutsController {
   }
 
   @Post(':sessionId/sets')
-  addSet(@CurrentUserId() userId: number,
+  addSet(
+    @CurrentUserId() userId: number,
     @Param('sessionId', ParseIntPipe) sessionId: number,
     @Body() dto: CreateWorkoutSetDto,
   ) {
     return this.workoutsService.addSet(userId, sessionId, dto);
   }
 
-  @Patch(':sessionId/finish')
-  finish(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+  // ✅ change PATCH -> POST (action endpoint)
+  @Post(':sessionId/finish')
+  finish(
+    @CurrentUserId() userId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
     return this.workoutsService.finish(userId, sessionId);
   }
 
   @Get(':sessionId/summary')
-  getSummary(@CurrentUserId() userId: number, @Param('sessionId', ParseIntPipe) sessionId: number) {
+  getSummary(
+    @CurrentUserId() userId: number,
+    @Param('sessionId', ParseIntPipe) sessionId: number,
+  ) {
     return this.workoutsService.getSummary(userId, sessionId);
   }
 }

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -12,12 +12,17 @@ import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
 export class WorkoutsService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private async ensureProgramDayOwnership(programId: number, programDayId: number) {
+  private async ensureProgramDayOwnership(
+    userId: number,
+    programId: number,
+    programDayId: number,
+  ) {
     const day = await this.prisma.programDay.findFirst({
-      where: { id: programDayId, programId },
+      where: { id: programDayId, programId, program: { userId } },
       select: { id: true },
     });
-    if (!day) throw new NotFoundException('Program day not found under program');
+
+    if (!day) throw new NotFoundException('Program day not found');
   }
 
   private async getSessionOr404(userId: number, sessionId: number) {
@@ -32,12 +37,13 @@ export class WorkoutsService {
         startedAt: true,
       },
     });
+
     if (!session) throw new NotFoundException('Workout session not found');
     return session;
   }
 
   async start(userId: number, dto: StartWorkoutSessionDto) {
-    await this.ensureProgramDayOwnership(dto.programId, dto.programDayId);
+    await this.ensureProgramDayOwnership(userId, dto.programId, dto.programDayId);
 
     return this.prisma.workoutSession.create({
       data: {
@@ -45,13 +51,19 @@ export class WorkoutsService {
         programId: dto.programId,
         programDayId: dto.programDayId,
       },
+      select: {
+        id: true,
+        startedAt: true,
+        endedAt: true,
+        programId: true,
+        programDayId: true,
+      },
     });
   }
 
   async getSession(userId: number, sessionId: number) {
     await this.getSessionOr404(userId, sessionId);
 
-    // IMPORTANT: findUnique({id}) can't include userId filter, so use findFirst
     return this.prisma.workoutSession.findFirst({
       where: { id: sessionId, userId },
       include: {
@@ -69,7 +81,11 @@ export class WorkoutsService {
     });
   }
 
-  async addSet(userId: number, sessionId: number, dto: CreateWorkoutSetDto): Promise<WorkoutSet> {
+  async addSet(
+    userId: number,
+    sessionId: number,
+    dto: CreateWorkoutSetDto,
+  ): Promise<WorkoutSet> {
     const session = await this.getSessionOr404(userId, sessionId);
     if (session.endedAt) throw new ConflictException('Workout session already finished');
 
@@ -82,7 +98,7 @@ export class WorkoutsService {
     try {
       return await this.prisma.workoutSet.create({
         data: {
-          sessionId,
+          sessionId: session.id,
           dayExerciseId: dto.dayExerciseId,
           setNumber: dto.setNumber,
           reps: dto.reps,
@@ -90,19 +106,40 @@ export class WorkoutsService {
         },
       });
     } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-        throw new ConflictException('Set number already exists for this exercise in this session');
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'Set number already exists for this exercise in this session',
+        );
       }
       throw e;
     }
   }
 
   async finish(userId: number, sessionId: number) {
-    await this.getSessionOr404(userId, sessionId);
-
-    return this.prisma.workoutSession.update({
-      where: { id: sessionId },
+    // סוגרים רק אם שייך למשתמש וגם עדיין לא הסתיים
+    const res = await this.prisma.workoutSession.updateMany({
+      where: { id: sessionId, userId, endedAt: null },
       data: { endedAt: new Date() },
+    });
+
+    if (res.count === 0) {
+      // או לא קיים, או לא שלך, או כבר נסגר
+      throw new NotFoundException('Workout session not found');
+    }
+
+    // מחזירים את ה-session אחרי סגירה כדי שה-UI יוכל ישר לנווט לסיכום
+    return this.prisma.workoutSession.findFirst({
+      where: { id: sessionId, userId },
+      select: {
+        id: true,
+        startedAt: true,
+        endedAt: true,
+        programId: true,
+        programDayId: true,
+      },
     });
   }
 
@@ -122,7 +159,6 @@ export class WorkoutsService {
   }
 
   async findOneDetailed(userId: number, sessionId: number) {
-    // enforce ownership
     await this.getSessionOr404(userId, sessionId);
 
     const session = await this.prisma.workoutSession.findFirst({
@@ -138,9 +174,7 @@ export class WorkoutsService {
     const plannedExercises = await this.prisma.dayExercise.findMany({
       where: { programDayId: session.programDayId },
       orderBy: { order: 'asc' },
-      include: {
-        exercise: { select: { id: true, name: true } },
-      },
+      include: { exercise: { select: { id: true, name: true } } },
     });
 
     const performedSets = await this.prisma.workoutSet.findMany({
@@ -182,18 +216,12 @@ export class WorkoutsService {
   }
 
   async getSummary(userId: number, sessionId: number) {
-    // enforce ownership
     await this.getSessionOr404(userId, sessionId);
 
     const session = await this.prisma.workoutSession.findFirst({
       where: { id: sessionId, userId },
-      select: {
-        id: true,
-        startedAt: true,
-        endedAt: true,
-      },
+      select: { id: true, startedAt: true, endedAt: true },
     });
-
     if (!session) throw new NotFoundException('Workout session not found');
 
     const sets = await this.prisma.workoutSet.findMany({
@@ -206,9 +234,7 @@ export class WorkoutsService {
         weight: true,
         dayExerciseId: true,
         dayExercise: {
-          select: {
-            exercise: { select: { id: true, name: true } },
-          },
+          select: { exercise: { select: { id: true, name: true } } },
         },
       },
     });
@@ -273,11 +299,7 @@ export class WorkoutsService {
       startedAt: session.startedAt,
       endedAt: session.endedAt,
       durationSeconds,
-      totals: {
-        totalSets,
-        totalReps,
-        totalVolume,
-      },
+      totals: { totalSets, totalReps, totalVolume },
       exercises,
     };
   }
@@ -290,22 +312,15 @@ export class WorkoutsService {
       select: { id: true, exerciseId: true },
     });
 
-    if (!de) {
-      throw new NotFoundException('Day exercise not found under session day');
-    }
+    if (!de) throw new NotFoundException('Day exercise not found under session day');
 
     const exerciseId = de.exerciseId;
 
-    // 1) Suggested: top working set from most recent prior session FOR THIS USER
     const lastSessionWithExercise = await this.prisma.workoutSession.findFirst({
       where: {
         userId,
         id: { not: sessionId },
-        sets: {
-          some: {
-            dayExercise: { exerciseId },
-          },
-        },
+        sets: { some: { dayExercise: { exerciseId } } },
       },
       orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
       select: { id: true, startedAt: true },
@@ -315,16 +330,8 @@ export class WorkoutsService {
 
     if (lastSessionWithExercise) {
       const topSet = await this.prisma.workoutSet.findFirst({
-        where: {
-          sessionId: lastSessionWithExercise.id,
-          dayExercise: { exerciseId },
-        },
-        orderBy: [
-          { weight: 'desc' },
-          { reps: 'desc' },
-          { setNumber: 'desc' },
-          { id: 'desc' },
-        ],
+        where: { sessionId: lastSessionWithExercise.id, dayExercise: { exerciseId } },
+        orderBy: [{ weight: 'desc' }, { reps: 'desc' }, { setNumber: 'desc' }, { id: 'desc' }],
         select: { id: true, weight: true, reps: true },
       });
 
@@ -344,7 +351,7 @@ export class WorkoutsService {
       }
     }
 
-    // 2) BestRecentE1rm: last 8 sessions where exercise performed FOR THIS USER
+    // window sessions
     const windowSessions = await this.prisma.workoutSession.findMany({
       where: {
         userId,
@@ -369,12 +376,7 @@ export class WorkoutsService {
           reps: { gte: 3, lte: 12 },
           weight: { gt: 0 },
         },
-        select: {
-          id: true,
-          sessionId: true,
-          reps: true,
-          weight: true,
-        },
+        select: { id: true, sessionId: true, reps: true, weight: true },
       });
 
       const epley = (w: number, r: number) => w * (1 + r / 30);


### PR DESCRIPTION
## What
Enforce user ownership consistently across Programs, ProgramDays, DayExercises
and WorkoutSessions, and complete the workout session flow.

This PR hardens ownership checks to prevent cross-user access
when creating and interacting with workout sessions.

## Why
While workout sessions were user-scoped, it was still possible to:
- Start sessions against programs owned by another user
- Link program days across users via indirect relations
- Create inconsistent ownership chains (Program → Day → Session)

This PR ensures ownership is validated end-to-end and that
all workout-related flows are properly isolated per user.

## Endpoints
- POST /api/workouts/sessions/start
- GET /api/workouts/sessions
- GET /api/workouts/sessions/:sessionId
- GET /api/workouts/sessions/:sessionId/details
- POST /api/workouts/sessions/:sessionId/sets
- POST /api/workouts/sessions/:sessionId/finish
- GET /api/workouts/sessions/:sessionId/summary
- GET /api/workouts/sessions/:sessionId/sets/defaults

(All endpoints enforce user ownership.)

## Features
- ProgramDay ownership validation before starting a workout session
- Consistent userId scoping across all workout queries
- Session lifecycle: start → add sets → finish → summary
- Safe handling of finished sessions (no further mutations allowed)
- Server-side workout summary generation for UI usage
- Temporary user identification via X-User-Id header

## Implementation Details
- Introduced ownership validation helpers for ProgramDay and WorkoutSession
- Replaced unsafe relations with user-scoped findFirst queries
- Ensured session creation validates Program → ProgramDay → User chain
- Finish session implemented as an action endpoint
- Summary and defaults queries are fully user-isolated
- No authentication or authorization framework added (MVP only)

## How to Test
1. Create two users (e.g. userId = 1 and userId = 2)
2. Create a program and program day for user 1
3. Start a workout session with:
   X-User-Id: 1 → should succeed
4. Attempt to start a session using the same program with:
   X-User-Id: 2 → should fail
5. Verify sessions list is user-specific
6. Attempt to add sets after finishing a session → blocked
7. Verify summary endpoint returns correct aggregated data

## Notes
- Prisma Studio can still be used to create invalid cross-user links manually;
  this is intentionally not handled here
- JWT authentication and DB-level constraints will be addressed separately
- This PR focuses strictly on API-level ownership enforcement

## Closes
Closes #27