### PR TITLE
Harden workout session start: derive programId from ProgramDay

### DIFF
--- a/apps/api/src/modules/workouts/dto/start-workout-session.dto.ts
+++ b/apps/api/src/modules/workouts/dto/start-workout-session.dto.ts
@@ -3,9 +3,5 @@ import { IsInt, Min } from 'class-validator';
 export class StartWorkoutSessionDto {
   @IsInt()
   @Min(1)
-  programId!: number;
-
-  @IsInt()
-  @Min(1)
   programDayId!: number;
 }

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -10,19 +10,16 @@ import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
 
 @Injectable()
 export class WorkoutsService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
-  private async ensureProgramDayOwnership(
-    userId: number,
-    programId: number,
-    programDayId: number,
-  ) {
+  private async ensureProgramDayOwnership(userId: number, programDayId: number): Promise<{ id: number; programId: number }> {
     const day = await this.prisma.programDay.findFirst({
-      where: { id: programDayId, programId, program: { userId } },
-      select: { id: true },
+      where: { id: programDayId, program: { userId } },
+      select: { id: true, programId: true },
     });
 
     if (!day) throw new NotFoundException('Program day not found');
+    return day;
   }
 
   private async getSessionOr404(userId: number, sessionId: number) {
@@ -43,13 +40,13 @@ export class WorkoutsService {
   }
 
   async start(userId: number, dto: StartWorkoutSessionDto) {
-    await this.ensureProgramDayOwnership(userId, dto.programId, dto.programDayId);
+    const day = await this.ensureProgramDayOwnership(userId, dto.programDayId);
 
     return this.prisma.workoutSession.create({
       data: {
         userId,
-        programId: dto.programId,
-        programDayId: dto.programDayId,
+        programId: day.programId,
+        programDayId: day.id,
       },
       select: {
         id: true,


### PR DESCRIPTION
## What
Harden POST /api/workouts/sessions/start by removing client-supplied programId
and deriving the program association server-side from ProgramDay.

## Why
Prevents invalid/mismatched Program–ProgramDay pairings and reduces reliance on
client-provided identifiers. Ensures sessions can only start from a ProgramDay
owned by the current user.

## Endpoints
- POST /api/workouts/sessions/start

## Features
- StartWorkoutSessionDto now accepts only programDayId
- ProgramDay ownership enforced via ProgramDay -> Program -> userId chain
- WorkoutSession creation derives program linkage from ProgramDay (no mismatch possible)

## Implementation Details
- Removed programId from StartWorkoutSessionDto validation
- Updated WorkoutsController start endpoint accordingly
- Updated WorkoutsService.start to:
  - validate ownership via ProgramDay->Program->userId
  - derive and persist the correct linkage

## How to Test
1. Create two users (userId=1, userId=2) with separate programs/days
2. Start session with X-User-Id: 1 and a programDayId owned by user 1 -> succeeds
3. Start session with X-User-Id: 2 using the same programDayId -> returns 404/blocked
4. Verify created session references the correct ProgramDay (and Program if stored)

## Notes
- DB-level integrity hardening (Studio bypass) is intentionally out of scope and will be handled in a separate issue.

## Closes
Closes #29