### PR TITLE
Summary progress indicator vs previous same-day session

### DIFF
--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -274,8 +274,9 @@ export class WorkoutsService {
 
     const session = await this.prisma.workoutSession.findFirst({
       where: { id: sessionId, userId },
-      select: { id: true, startedAt: true, endedAt: true },
+      select: { id: true, startedAt: true, endedAt: true, programDayId: true },
     });
+
     if (!session) throw new NotFoundException('Workout session not found');
 
     const sets = await this.prisma.workoutSet.findMany({
@@ -295,7 +296,9 @@ export class WorkoutsService {
 
     const durationSeconds =
       session.endedAt
-        ? Math.floor((session.endedAt.getTime() - session.startedAt.getTime()) / 1000)
+        ? Math.floor(
+          (session.endedAt.getTime() - session.startedAt.getTime()) / 1000,
+        )
         : null;
 
     let totalSets = 0;
@@ -303,6 +306,12 @@ export class WorkoutsService {
     let totalVolume = 0;
 
     type TopSet = { weight: number; reps: number };
+    type ProgressState =
+      | 'IMPROVED'
+      | 'REGRESSED'
+      | 'SAME'
+      | 'NO_BASELINE';
+
     type ExerciseAgg = {
       exerciseId: number;
       name: string;
@@ -346,7 +355,85 @@ export class WorkoutsService {
       byExercise.set(ex.id, curr);
     }
 
-    const exercises = Array.from(byExercise.values()).sort((a, b) => a.exerciseId - b.exerciseId);
+    // 🔎 Find previous session of the same ProgramDay
+    const previousSession = await this.prisma.workoutSession.findFirst({
+      where: {
+        userId,
+        programDayId: session.programDayId,
+        startedAt: { lt: session.startedAt },
+      },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true },
+    });
+
+    type ExerciseSummary = {
+      exerciseId: number;
+      name: string;
+      sets: number;
+      repsTotal: number;
+      volume: number;
+      currentTopSet: TopSet | null;
+      previousTopSet: TopSet | null;
+      progress: ProgressState;
+    };
+
+
+    const exercises: ExerciseSummary[] = [];
+
+    for (const curr of byExercise.values()) {
+      let previousTopSet: TopSet | null = null;
+      let progress: ProgressState = 'NO_BASELINE';
+
+      if (previousSession && curr.topSet) {
+        const prevSet = await this.prisma.workoutSet.findFirst({
+          where: {
+            sessionId: previousSession.id,
+            dayExercise: { exerciseId: curr.exerciseId },
+          },
+          orderBy: [
+            { weight: 'desc' },
+            { reps: 'desc' },
+            { setNumber: 'desc' },
+            { id: 'desc' },
+          ],
+          select: { weight: true, reps: true },
+        });
+
+        if (prevSet) {
+          previousTopSet = {
+            weight: prevSet.weight,
+            reps: prevSet.reps,
+          };
+
+          if (curr.topSet.weight > prevSet.weight) {
+            progress = 'IMPROVED';
+          } else if (
+            curr.topSet.weight === prevSet.weight &&
+            curr.topSet.reps > prevSet.reps
+          ) {
+            progress = 'IMPROVED';
+          } else if (
+            curr.topSet.weight === prevSet.weight &&
+            curr.topSet.reps === prevSet.reps
+          ) {
+            progress = 'SAME';
+          } else {
+            progress = 'REGRESSED';
+          }
+        }
+      }
+
+      exercises.push({
+        exerciseId: curr.exerciseId,
+        name: curr.name,
+        sets: curr.sets,
+        repsTotal: curr.repsTotal,
+        volume: curr.volume,
+        currentTopSet: curr.topSet,
+        previousTopSet,
+        progress,
+      });
+    }
 
     return {
       sessionId: session.id,
@@ -357,6 +444,7 @@ export class WorkoutsService {
       exercises,
     };
   }
+
 
   async getSetDefaults(userId: number, sessionId: number, dayExerciseId: number) {
     const session = await this.getSessionOr404(userId, sessionId);

--- a/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
+++ b/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
@@ -1,16 +1,76 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
 
+type TopSet = { weight: number; reps: number };
+type ProgressState = 'IMPROVED' | 'REGRESSED' | 'SAME' | 'NO_BASELINE';
+
+type SummaryExercise = {
+  exerciseId: number;
+  name: string;
+  sets: number;
+  repsTotal: number;
+  volume: number;
+  currentTopSet: TopSet | null;
+  previousTopSet: TopSet | null;
+  progress: ProgressState;
+};
+
+type Summary = {
+  sessionId: number;
+  startedAt: string;
+  endedAt: string | null;
+  durationSeconds: number | null;
+  totals: { totalSets: number; totalReps: number; totalVolume: number };
+  exercises: SummaryExercise[];
+};
+
+function progressEmoji(p: ProgressState) {
+  if (p === 'IMPROVED') return '🟢';
+  if (p === 'SAME') return '🟡';
+  if (p === 'REGRESSED') return '🔴';
+  return '';
+}
+
+function formatTopSet(s: TopSet | null) {
+  if (!s) return '—';
+  return `${s.weight} × ${s.reps}`;
+}
+
+function formatDelta(curr: TopSet | null, prev: TopSet | null) {
+  if (!curr || !prev) return '—';
+
+  if (curr.weight !== prev.weight) {
+    const diff = curr.weight - prev.weight;
+    const sign = diff > 0 ? '+' : '';
+    return `${sign}${diff}kg`;
+  }
+
+  if (curr.reps !== prev.reps) {
+    const diff = curr.reps - prev.reps;
+    const sign = diff > 0 ? '+' : '';
+    return `${sign}${diff} rep`;
+  }
+
+  return '=';
+}
+
+function formatDuration(seconds: number | null) {
+  if (seconds === null) return '—';
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
 export default function SessionSummaryPage() {
   const params = useParams<{ sessionId: string }>();
   const sessionId = Number(params.sessionId);
 
-  const [data, setData] = useState<any>(null);
+  const [data, setData] = useState<Summary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
@@ -18,7 +78,7 @@ export default function SessionSummaryPage() {
     try {
       const token = getToken();
       if (!token) throw new Error('Please login first (go to /)');
-      const s = await apiFetch(`/workouts/sessions/${sessionId}/summary`, { token });
+      const s = await apiFetch<Summary>(`/workouts/sessions/${sessionId}/summary`, { token });
       setData(s);
     } catch (e: any) {
       setError(e?.message ?? 'Failed to load summary');
@@ -28,26 +88,128 @@ export default function SessionSummaryPage() {
   useEffect(() => {
     if (!Number.isFinite(sessionId)) return;
     load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
+
+  const sortedExercises = useMemo(() => {
+    if (!data) return [];
+    return [...data.exercises].sort((a, b) => a.name.localeCompare(b.name));
+  }, [data]);
 
   return (
     <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
       <div className="max-w-3xl mx-auto space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold">Summary — Session #{sessionId}</h1>
-          <Link
-            href="/programs"
-            className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-          >
-            Back to Programs
-          </Link>
+          <div className="flex gap-2">
+            <button
+              onClick={load}
+              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
+            >
+              Refresh
+            </button>
+            <Link
+              href="/programs"
+              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
+            >
+              Back to Programs
+            </Link>
+          </div>
         </div>
 
         {error && <p className="text-red-400 text-sm">{error}</p>}
 
-        <pre className="rounded-md bg-zinc-800 border border-zinc-700 p-4 overflow-auto text-sm">
-{JSON.stringify(data, null, 2)}
-        </pre>
+        {!data ? (
+          <p>Loading…</p>
+        ) : (
+          <>
+            {/* Totals card */}
+            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4 space-y-2">
+              <div className="flex items-baseline justify-between">
+                <div className="font-semibold">Workout totals</div>
+                <div className="text-sm text-zinc-300">
+                  Duration: {formatDuration(data.durationSeconds)}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3 text-sm">
+                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
+                  <div className="text-zinc-400 text-xs">Sets</div>
+                  <div className="text-lg font-semibold">{data.totals.totalSets}</div>
+                </div>
+
+                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
+                  <div className="text-zinc-400 text-xs">Reps</div>
+                  <div className="text-lg font-semibold">{data.totals.totalReps}</div>
+                </div>
+
+                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
+                  <div className="text-zinc-400 text-xs">Volume</div>
+                  <div className="text-lg font-semibold">{data.totals.totalVolume}</div>
+                </div>
+              </div>
+
+              <div className="text-xs text-zinc-400">
+                Started: {new Date(data.startedAt).toLocaleString()}
+                {data.endedAt ? ` · Ended: ${new Date(data.endedAt).toLocaleString()}` : ''}
+              </div>
+            </div>
+
+            {/* Exercises list */}
+            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4">
+              <div className="font-semibold mb-3">Exercise progress</div>
+
+              <div className="space-y-3">
+                {sortedExercises.map((ex) => (
+                  <div
+                    key={ex.exerciseId}
+                    className="rounded-md bg-zinc-900 border border-zinc-700 p-3"
+                  >
+                    <div className="flex items-baseline justify-between">
+                      <div className="font-semibold">
+                        <span className="mr-2">{progressEmoji(ex.progress)}</span>
+                        {ex.name}
+                      </div>
+
+                      <div className="text-sm text-zinc-400">
+                        {ex.sets} sets · {ex.repsTotal} reps · vol {ex.volume}
+                      </div>
+                    </div>
+
+                    <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
+                      <div>
+                        <div className="text-zinc-400 text-xs">Current top set</div>
+                        <div className="font-semibold">{formatTopSet(ex.currentTopSet)}</div>
+                      </div>
+
+                      <div>
+                        <div className="text-zinc-400 text-xs">Previous top set</div>
+                        <div className="font-semibold">{formatTopSet(ex.previousTopSet)}</div>
+                      </div>
+
+                      <div>
+                        <div className="text-zinc-400 text-xs">Delta</div>
+                        <div className="font-semibold">
+                          {ex.progress === 'NO_BASELINE'
+                            ? '—'
+                            : formatDelta(ex.currentTopSet, ex.previousTopSet)}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+
+                {sortedExercises.length === 0 && (
+                  <div className="text-zinc-400 text-sm">No performed sets in this session.</div>
+                )}
+              </div>
+
+              <div className="mt-4 text-xs text-zinc-400">
+                Legend: 🟢 improved · 🟡 same · 🔴 regressed
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## What
Add per-exercise progress indicators to the workout session summary by comparing
each exercise’s current top set against the previous session of the same ProgramDay.

Summary UI is now human-readable and highlights improvement / regression / no-change
using a simple emoji indicator and a clear delta.

## Why
Raw summary JSON is not usable for real users and does not communicate progress.

Users need immediate feedback after finishing a workout:
- Did I improve on this exercise?
- Did I stay the same?
- Did I regress?

Comparing only against the previous session of the same ProgramDay keeps the progress
signal relevant and avoids comparing against unrelated workout types.

## Scope
- Extend session summary response with previous top set and progress state
- Show progress indicator (🟢 / 🟡 / 🔴) per exercise in the summary screen
- Display current vs previous top set and a readable delta (+kg / +rep / =)

## Out of scope
- Graphs and trends over time
- E1RM calculations
- PR badges
- Weekly dashboards
- UI/UX polish and mobile layout work

## Implementation details
- Summary API now finds the previous session for the same `programDayId` and user
- For each exercise, previous top set is derived from that previous session (if exists)
- Progress state is computed:
  - Higher weight → IMPROVED
  - Same weight + higher reps → IMPROVED
  - Same weight + same reps → SAME
  - Otherwise → REGRESSED
  - No previous baseline → NO_BASELINE
- Summary page renders a totals card + per-exercise progress list

## How to test
1. Finish a workout session with performed sets → open summary
2. Verify totals are displayed (sets, reps, volume, duration)
3. Finish another session of the same ProgramDay with changes:
   - Increase weight at same reps → 🟢 and +kg delta
   - Increase reps at same weight → 🟢 and +rep delta
   - Same top set → 🟡 and '='
   - Lower top set → 🔴 and negative delta
4. Verify first-ever session for a ProgramDay shows no baseline indicator

## Notes
- This PR improves the summary UX without introducing charts or dashboards
- Establishes the foundation for a future dashboard (last workout + weekly trend)

## Closes
Closes #42
