### PR TITLE
Introduce primary muscle mapping for exercises

### DIFF
--- a/apps/api/prisma/migrations/20260216074236_add_exercise_primary_muscle/migration.sql
+++ b/apps/api/prisma/migrations/20260216074236_add_exercise_primary_muscle/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `primaryMuscle` to the `Exercise` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "MuscleGroup" AS ENUM ('CHEST', 'BACK', 'SHOULDERS', 'BICEPS', 'TRICEPS', 'QUADS', 'HAMSTRINGS', 'GLUTES', 'CALVES', 'ABS');
+
+-- AlterTable
+ALTER TABLE "Exercise" ADD COLUMN     "primaryMuscle" "MuscleGroup" NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -47,6 +47,8 @@ model ProgramDay {
 model Exercise {
   id        Int           @id @default(autoincrement())
   name      String        @unique
+  primaryMuscle MuscleGroup
+
   exercises DayExercise[]
 }
 
@@ -71,6 +73,20 @@ enum ProgramType {
   FULL_BODY
   CUSTOM
 }
+
+enum MuscleGroup {
+  CHEST
+  BACK
+  SHOULDERS
+  BICEPS
+  TRICEPS
+  QUADS
+  HAMSTRINGS
+  GLUTES
+  CALVES
+  ABS
+}
+
 
 model WorkoutSession {
   id           Int        @id @default(autoincrement())

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, ProgramType } from '@prisma/client';
+import { PrismaClient, ProgramType, MuscleGroup } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
@@ -41,22 +41,23 @@ async function main() {
   });
 
   // 5) Exercises
-  const exNames = [
-    'Hip Thrust',
-    'Romanian Deadlift',
-    'Bulgarian Split Squat',
-    'Lat Pulldown',
-    'Dumbbell Row',
-    'Shoulder Press',
-  ];
+  const exSeed = [
+    { name: 'Hip Thrust', primaryMuscle: MuscleGroup.GLUTES },
+    { name: 'Romanian Deadlift', primaryMuscle: MuscleGroup.HAMSTRINGS },
+    { name: 'Bulgarian Split Squat', primaryMuscle: MuscleGroup.QUADS },
+    { name: 'Lat Pulldown', primaryMuscle: MuscleGroup.BACK },
+    { name: 'Dumbbell Row', primaryMuscle: MuscleGroup.BACK },
+    { name: 'Shoulder Press', primaryMuscle: MuscleGroup.SHOULDERS },
+  ] as const;
 
   const exercises = await Promise.all(
-    exNames.map((name) =>
+    exSeed.map((ex) =>
       prisma.exercise.create({
-        data: { name },
+        data: { name: ex.name, primaryMuscle: ex.primaryMuscle },
       }),
     ),
   );
+
 
   const byName = new Map(exercises.map((e) => [e.name, e.id] as const));
 

--- a/apps/api/src/modules/exercises/dto/create-exercise.dto.ts
+++ b/apps/api/src/modules/exercises/dto/create-exercise.dto.ts
@@ -1,7 +1,12 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { MuscleGroup } from '@prisma/client';
+
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateExerciseDto {
   @IsString()
   @IsNotEmpty()
   name!: string;
+  
+  @IsEnum(MuscleGroup)
+  primaryMuscle!: MuscleGroup;
 }

--- a/apps/api/src/modules/exercises/dto/update-exercise.dto.ts
+++ b/apps/api/src/modules/exercises/dto/update-exercise.dto.ts
@@ -1,4 +1,8 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateExerciseDto } from './create-exercise.dto';
+import { IsOptional, IsString, IsNotEmpty } from 'class-validator';
 
-export class UpdateExerciseDto extends PartialType(CreateExerciseDto) {}
+export class UpdateExerciseDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  name?: string;
+}

--- a/apps/api/src/modules/exercises/exercises.controller.ts
+++ b/apps/api/src/modules/exercises/exercises.controller.ts
@@ -8,11 +8,14 @@ import {
   Patch,
   Post,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { ExercisesService } from './exercises.service';
 import { CreateExerciseDto } from './dto/create-exercise.dto';
 import { UpdateExerciseDto } from './dto/update-exercise.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('exercises')
 export class ExercisesController {
   constructor(private readonly exercisesService: ExercisesService) { }

--- a/apps/api/src/modules/exercises/exercises.service.ts
+++ b/apps/api/src/modules/exercises/exercises.service.ts
@@ -18,7 +18,7 @@ type ProgressQuery = {
 
 @Injectable()
 export class ExercisesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
   private normalizeName(name: string): string {
     return name.trim();
@@ -26,10 +26,12 @@ export class ExercisesService {
 
   async create(dto: CreateExerciseDto): Promise<Exercise> {
     const name = this.normalizeName(dto.name);
+    const primaryMuscle = dto.primaryMuscle;
+
 
     try {
       return await this.prisma.exercise.create({
-        data: { name },
+        data: { name, primaryMuscle },
       });
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
@@ -56,10 +58,16 @@ export class ExercisesService {
   async update(id: number, dto: UpdateExerciseDto): Promise<Exercise> {
     await this.findOne(id);
 
+    if (!dto.name) {
+      throw new BadRequestException('Nothing to update');
+    }
+
+    const name = this.normalizeName(dto.name);
+
     try {
       return await this.prisma.exercise.update({
         where: { id },
-        data: dto.name ? { name: this.normalizeName(dto.name) } : {},
+        data: { name },
       });
     } catch (e) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
@@ -68,6 +76,7 @@ export class ExercisesService {
       throw e;
     }
   }
+
 
   async remove(id: number): Promise<void> {
     await this.findOne(id);
@@ -78,7 +87,7 @@ export class ExercisesService {
     // 1) validate exercise exists
     const exercise = await this.prisma.exercise.findUnique({
       where: { id: exerciseId },
-      select: { id: true, name: true },
+      select: { id: true, name: true, primaryMuscle: true },
     });
     if (!exercise) throw new NotFoundException('Exercise not found');
 
@@ -174,11 +183,11 @@ export class ExercisesService {
 
     const bestWeightSet = bestWeightRow
       ? {
-          weight: bestWeightRow.weight,
-          reps: bestWeightRow.reps,
-          performedAt: bestWeightRow.createdAt,
-          sessionId: bestWeightRow.sessionId,
-        }
+        weight: bestWeightRow.weight,
+        reps: bestWeightRow.reps,
+        performedAt: bestWeightRow.createdAt,
+        sessionId: bestWeightRow.sessionId,
+      }
       : null;
 
     // best volume set: compute exact max(reps * weight) in TS

--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -89,7 +89,7 @@ export class WorkoutsService {
           include: {
             dayExercise: {
               include: {
-                exercise: { select: { id: true, name: true } },
+                exercise: { select: { id: true, name: true, primaryMuscle: true } },
               },
             },
           },
@@ -245,7 +245,7 @@ export class WorkoutsService {
     const plannedExercises = await this.prisma.dayExercise.findMany({
       where: { programDayId: session.programDayId },
       orderBy: { order: 'asc' },
-      include: { exercise: { select: { id: true, name: true } } },
+      include: { exercise: { select: { id: true, name: true, primaryMuscle: true } } },
     });
 
     const performedSets = await this.prisma.workoutSet.findMany({
@@ -306,7 +306,7 @@ export class WorkoutsService {
         weight: true,
         dayExerciseId: true,
         dayExercise: {
-          select: { exercise: { select: { id: true, name: true } } },
+          select: { exercise: { select: { id: true, name: true, primaryMuscle: true } } }
         },
       },
     });


### PR DESCRIPTION
## What
Introduce mandatory muscle mapping for exercises by adding a `primaryMuscle`
enum field to the Exercise model.

This establishes the structural foundation required for future
muscle-level aggregation, trend detection and progress analytics.

## Why
Setlyx is evolving into a progress validation engine.

Muscle-level aggregation is a core architectural requirement for:
- Volume tracking per muscle
- Strength trend detection
- Program version comparison
- Future dashboard insights

Without strict muscle mapping, the analytics layer would be unreliable.

## Scope
- Added `primaryMuscle` enum to Prisma schema
- Removed fallback/default muscle values
- Updated Exercise creation logic to require muscle mapping
- Updated DTO validation with `@IsEnum(MuscleGroup)`
- Adjusted seed data to explicitly assign muscles
- Ensured update flow does not allow muscle mutation

## Out of scope
- Muscle-level aggregation queries
- Progress dashboard changes
- Program versioning
- UI integration

## Implementation details
- MuscleGroup enum enforced at DB level
- No nullable or default muscle values allowed
- ExercisesService create() now requires `primaryMuscle`
- Update operation restricted to name changes only
- JWT guard applied to ExercisesController

## Manual verification
- Creating exercise without `primaryMuscle` fails validation
- Creating exercise with valid enum succeeds
- Duplicate name returns 409 Conflict
- GET /exercises returns muscle mapping
- Progress endpoint still functions correctly

## Notes
- This is a backend foundation PR
- Required before implementing muscle aggregation logic
- No UI changes included

## Closes
Closes #46
