### PR TITLE
Add muscle totals to workout session summary

### DIFF
--- a/apps/api/src/modules/workouts/workouts.service.ts
+++ b/apps/api/src/modules/workouts/workouts.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma, WorkoutSet } from '@prisma/client';
+import { MuscleGroup, Prisma, WorkoutSet } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { StartWorkoutSessionDto } from './dto/start-workout-session.dto';
 import { CreateWorkoutSetDto } from './dto/create-workout-set.dto';
@@ -338,11 +338,34 @@ export class WorkoutsService {
       topSet: TopSet | null;
     };
 
+    type MuscleAgg = {
+      muscle: MuscleGroup;
+      totalSets: number;
+      totalReps: number;
+      totalVolume: number;
+    };
+
     const byExercise = new Map<number, ExerciseAgg>();
+    const byMuscle = new Map<MuscleGroup, MuscleAgg>();
+
 
     for (const s of sets) {
       const ex = s.dayExercise.exercise;
+      const muscle = ex.primaryMuscle;
       const volume = s.reps * s.weight;
+
+      const m = byMuscle.get(muscle) ?? {
+        muscle,
+        totalSets: 0,
+        totalReps: 0,
+        totalVolume: 0,
+      };
+
+      m.totalSets += 1;
+      m.totalReps += s.reps;
+      m.totalVolume += volume;
+
+      byMuscle.set(muscle, m);
 
       totalSets += 1;
       totalReps += s.reps;
@@ -452,12 +475,18 @@ export class WorkoutsService {
       });
     }
 
+    const muscleTotals = Array.from(byMuscle.values()).sort((a, b) =>
+      a.muscle.localeCompare(b.muscle),
+    );
+
+
     return {
       sessionId: session.id,
       startedAt: session.startedAt,
       endedAt: session.endedAt,
       durationSeconds,
       totals: { totalSets, totalReps, totalVolume },
+      muscleTotals,
       exercises,
     };
   }


### PR DESCRIPTION
## What
Extend the workout session summary endpoint to include per-muscle aggregation totals
(sets, reps, volume) based on each exercise’s `primaryMuscle`.

## Why
Muscle-level aggregation is a core building block for progress dashboards and trend
detection. It allows us to measure workload distribution and later classify progress
by muscle group over time windows.

## Scope
- Add `primaryMuscle` to the summary query selection
- Aggregate `muscleTotals` for a session (sets/reps/volume)
- Keep existing exercise-level summary intact

## Out of scope
- Muscle-level progress vs previous session
- Rolling window trends (4–6 weeks)
- UI changes (dashboard charts/tiles)

## Implementation details
- Aggregation computed in-memory while iterating performed sets
- `muscleTotals` returned as a sorted array for stable UI output
- No schema changes required (uses existing `Exercise.primaryMuscle`)

## How to test
1. Ensure exercises have `primaryMuscle` populated (seed or create via API)
2. Start a workout session and log sets for multiple exercises
3. Finish the session
4. Call `GET /api/workouts/sessions/:sessionId/summary`
5. Verify `muscleTotals` exists and totals match performed sets
   - totals.totalSets should equal sum of muscleTotals.totalSets

## Notes
- Next issue will add muscle-level comparison vs previous same-day session (Issue #50)

## Closes
Closes #48
