### PR TITLE
Add responsive app navigation for desktop/mobile

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.575.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -4838,6 +4839,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.575.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
+      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "lucide-react": "^0.575.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -3,10 +3,9 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '@/lib/api';
-import { getToken } from '@/lib/auth';
-import { clearToken } from '@/lib/auth';
+import { clearToken, getToken } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
-
+import { AppShell } from '@/components/app-shell';
 
 type ActiveSession = {
     id: number;
@@ -36,7 +35,6 @@ export default function HomePage() {
         router.replace('/');
     }
 
-
     async function load() {
         setError(null);
 
@@ -56,8 +54,8 @@ export default function HomePage() {
 
             setActive(activeRes.session);
             setLast(lastRes.session);
-        } catch (e: any) {
-            setError(e?.message ?? 'Failed to load home data');
+        } catch (e: unknown) {
+            setError(e instanceof Error ? e.message : 'Failed to load home data');
         }
     }
 
@@ -66,87 +64,82 @@ export default function HomePage() {
     }, []);
 
     return (
-        <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
-            <div className="max-w-3xl mx-auto space-y-8">
+        <AppShell
+            title="Home"
+            actions={
+                <button
+                    className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
+                    onClick={logout}
+                >
+                    Logout
+                </button>
+            }
+        >
+            {error && <p className="text-red-400 text-sm">{error}</p>}
 
-                <div className="flex items-center justify-between">
-                    <h1 className="text-4xl font-bold">Home</h1>
-                    <button
-                        className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-                        onClick={logout}
-                    >
-                        Logout
-                    </button>
-                </div>
+            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
+                <div className="font-semibold text-lg">Workout status</div>
 
-
-                {error && <p className="text-red-400 text-sm">{error}</p>}
-
-                {/* Active session card */}
-                <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
-                    <div className="font-semibold text-lg">Workout status</div>
-
-                    {active ? (
-                        <>
-                            <div className="text-zinc-300 text-sm">
-                                You have an active workout started at{' '}
-                                {new Date(active.startedAt).toLocaleString()}
-                            </div>
-
-                            <Link
-                                href={`/workouts/sessions/${active.id}`}
-                                className="inline-block rounded-md bg-green-500 text-black px-4 py-2 font-semibold"
-                            >
-                                Resume workout
-                            </Link>
-                        </>
-                    ) : (
-                        <>
-                            <div className="text-zinc-300 text-sm">
-                                No active workout session.
-                            </div>
-
-                            <Link
-                                href="/programs"
-                                className="inline-block rounded-md bg-white text-black px-4 py-2 font-semibold"
-                            >
-                                Start workout
-                            </Link>
-                        </>
-                    )}
-                </div>
-
-                {/* Last workout card */}
-                <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
-                    <div className="font-semibold text-lg">Last workout</div>
-
-                    {last ? (
-                        <>
-                            <div className="text-zinc-200">
-                                <span className="font-semibold">
-                                    {last.program.name}
-                                </span>{' '}
-                                — {last.programDay.name}
-                            </div>
-
-                            <div className="text-sm text-zinc-400">
-                                Completed at {new Date(last.endedAt).toLocaleString()}
-                            </div>
-
-                            <Link
-                                href={`/workouts/sessions/${last.id}/summary`}
-                                className="inline-block rounded-md bg-zinc-700 px-4 py-2"
-                            >
-                                View summary
-                            </Link>
-                        </>
-                    ) : (
-                        <div className="text-zinc-400 text-sm">
-                            No workouts completed yet.
+                {active ? (
+                    <>
+                        <div className="text-zinc-300 text-sm">
+                            You have an active workout started at{' '}
+                            {new Date(active.startedAt).toLocaleString()}
                         </div>
-                    )}
-                </div>
+
+                        <Link
+                            href={`/workouts/sessions/${active.id}`}
+                            className="inline-block rounded-md bg-green-500 text-black px-4 py-2 font-semibold"
+                        >
+                            Resume workout
+                        </Link>
+                    </>
+                ) : (
+                    <>
+                        <div className="text-zinc-300 text-sm">
+                            No active workout session.
+                        </div>
+
+                        <Link
+                            href="/programs"
+                            className="inline-block rounded-md bg-white text-black px-4 py-2 font-semibold"
+                        >
+                            Start workout
+                        </Link>
+                    </>
+                )}
             </div>
-        </main>
+
+            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
+                <div className="font-semibold text-lg">Last workout</div>
+
+                {last ? (
+                    <>
+                        <div className="text-zinc-200">
+                            <span className="font-semibold">
+                                {last.program.name}
+                            </span>{' '}
+                            - {last.programDay.name}
+                        </div>
+
+                        <div className="text-sm text-zinc-400">
+                            Completed at {new Date(last.endedAt).toLocaleString()}
+                        </div>
+
+                        <Link
+                            href={`/workouts/sessions/${last.id}/summary`}
+                            className="inline-block rounded-md bg-zinc-700 px-4 py-2"
+                        >
+                            View summary
+                        </Link>
+                    </>
+                ) : (
+                    <div className="text-zinc-400 text-sm">
+                        No workouts completed yet.
+                    </div>
+                )}
+            </div>
+        </AppShell>
     );
 }
+

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,8 +39,8 @@ export default function HomePage() {
 
       router.push('/home');
 
-    } catch (e: any) {
-      setError(e?.message ?? 'Login failed');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Login failed');
     }
   }
 
@@ -51,8 +51,8 @@ export default function HomePage() {
     try {
       const data = await apiFetch<Program[]>('/programs', { token });
       setPrograms(data);
-    } catch (e: any) {
-      setError(e?.message ?? 'Failed to load programs');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load programs');
     } finally {
       setLoadingPrograms(false);
     }
@@ -140,3 +140,4 @@ export default function HomePage() {
     </main>
   );
 }
+

--- a/apps/web/src/app/programs/page.tsx
+++ b/apps/web/src/app/programs/page.tsx
@@ -4,153 +4,141 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
-import Link from 'next/link';
-
+import { AppShell } from '@/components/app-shell';
 
 type ActiveSession = {
-    id: number;
-    startedAt: string;
-    endedAt: string | null;
-    programId: number;
-    programDayId: number;
+  id: number;
+  startedAt: string;
+  endedAt: string | null;
+  programId: number;
+  programDayId: number;
 } | null;
 
 export default function ProgramsStartResumePage() {
-    const router = useRouter();
+  const router = useRouter();
 
-    const [loading, setLoading] = useState(true);
-    const [active, setActive] = useState<ActiveSession>(null);
-    const [programDayId, setProgramDayId] = useState<number>(1);
-    const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [active, setActive] = useState<ActiveSession>(null);
+  const [programDayId, setProgramDayId] = useState<number>(1);
+  const [error, setError] = useState<string | null>(null);
 
-    async function loadActive() {
-        setError(null);
-        setLoading(true);
-        try {
-            const token = getToken();
-            if (!token) throw new Error('Please login first (go to /)');
-            const data = await apiFetch<{ session: ActiveSession }>(
-                '/workouts/sessions/active',
-                { token }
-            );
-            setActive(data.session);
+  async function loadActive() {
+    setError(null);
+    setLoading(true);
 
-        } catch (e: any) {
-            setError(e?.message ?? 'Failed to load active session');
-        } finally {
-            setLoading(false);
-        }
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const data = await apiFetch<{ session: ActiveSession }>('/workouts/sessions/active', {
+        token,
+      });
+
+      setActive(data.session);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load active session');
+    } finally {
+      setLoading(false);
     }
+  }
 
-    useEffect(() => {
-        loadActive();
-    }, []);
+  useEffect(() => {
+    loadActive();
+  }, []);
 
-    async function onStart() {
-        setError(null);
-        try {
-            const token = getToken();
-            if (!token) throw new Error('Please login first (go to /)');
+  async function onStart() {
+    setError(null);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
 
-            const session = await apiFetch<NonNullable<ActiveSession>>(
-                '/workouts/sessions/start',
-                {
-                    method: 'POST',
-                    token,
-                    body: JSON.stringify({ programDayId }),
-                },
-            );
+      const session = await apiFetch<NonNullable<ActiveSession>>('/workouts/sessions/start', {
+        method: 'POST',
+        token,
+        body: JSON.stringify({ programDayId }),
+      });
 
-            setActive(session);
-            router.push(`/workouts/sessions/${session.id}`);
-        } catch (e: any) {
-            setError(e?.message ?? 'Failed to start session');
-            await loadActive(); // סנכרון אחרי 409
-        }
+      setActive(session);
+      router.push(`/workouts/sessions/${session.id}`);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to start session');
+      await loadActive();
     }
+  }
 
-    function onResume() {
-        if (!active?.id) return;
-        router.push(`/workouts/sessions/${active.id}`);
-    }
+  function onResume() {
+    if (!active?.id) return;
+    router.push(`/workouts/sessions/${active.id}`);
+  }
 
-    return (
-        <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
-            <div className="max-w-3xl mx-auto space-y-6">
-                <h1 className="text-3xl font-bold">Programs — Start/Resume (Test UI)</h1>
+  return (
+    <AppShell title="Programs - Start/Resume">
+      {error && <p className="text-sm text-red-400">{error}</p>}
 
-                <div className="flex gap-2">
-                    <Link href="/home" className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700">
-                        Home
-                    </Link>
-                </div>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="space-y-4 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+          <div>
+            <div className="mb-1 font-semibold">Active session</div>
+            {active ? (
+              <div className="text-sm text-zinc-200">
+                <div>ID: {active.id}</div>
+                <div>ProgramDay: {active.programDayId}</div>
+                <div>Started: {new Date(active.startedAt).toLocaleString()}</div>
+              </div>
+            ) : (
+              <div className="text-sm text-zinc-400">No active session</div>
+            )}
+          </div>
 
-                {error && <p className="text-red-400 text-sm">{error}</p>}
+          {!active ? (
+            <div className="flex items-end gap-3">
+              <label className="flex flex-col gap-1">
+                <span className="text-sm text-zinc-400">programDayId (temp)</span>
+                <input
+                  className="w-40 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                  type="number"
+                  min={1}
+                  value={programDayId}
+                  onChange={(e) => setProgramDayId(Number(e.target.value))}
+                />
+              </label>
 
-                {loading ? (
-                    <p>Loading…</p>
-                ) : (
-                    <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4 space-y-4">
-                        <div>
-                            <div className="font-semibold mb-1">Active session</div>
-                            {active ? (
-                                <div className="text-sm text-zinc-200">
-                                    <div>ID: {active.id}</div>
-                                    <div>ProgramDay: {active.programDayId}</div>
-                                    <div>Started: {new Date(active.startedAt).toLocaleString()}</div>
-                                </div>
-                            ) : (
-                                <div className="text-sm text-zinc-400">No active session</div>
-                            )}
-                        </div>
+              <button
+                className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
+                onClick={onStart}
+              >
+                Start workout
+              </button>
 
-                        {!active ? (
-                            <div className="flex gap-3 items-end">
-                                <label className="flex flex-col gap-1">
-                                    <span className="text-sm text-zinc-400">programDayId (temp)</span>
-                                    <input
-                                        className="w-40 rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 outline-none"
-                                        type="number"
-                                        min={1}
-                                        value={programDayId}
-                                        onChange={(e) => setProgramDayId(Number(e.target.value))}
-                                    />
-                                </label>
-
-                                <button
-                                    className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white"
-                                    onClick={onStart}
-                                >
-                                    Start workout
-                                </button>
-
-                                <button
-                                    className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-                                    onClick={loadActive}
-                                >
-                                    Refresh
-                                </button>
-                            </div>
-                        ) : (
-                            <div className="flex gap-3">
-                                <button
-                                    className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white"
-                                    onClick={onResume}
-                                >
-                                    Resume workout
-                                </button>
-
-                                <button
-                                    className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-                                    onClick={loadActive}
-                                >
-                                    Refresh
-                                </button>
-                            </div>
-                        )}
-                    </div>
-                )}
+              <button
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
+                onClick={loadActive}
+              >
+                Refresh
+              </button>
             </div>
-        </main>
-    );
+          ) : (
+            <div className="flex gap-3">
+              <button
+                className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
+                onClick={onResume}
+              >
+                Resume workout
+              </button>
+
+              <button
+                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
+                onClick={loadActive}
+              >
+                Refresh
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </AppShell>
+  );
 }
+

--- a/apps/web/src/app/progress/page.tsx
+++ b/apps/web/src/app/progress/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { AppShell } from '@/components/app-shell';
+
+export default function ProgressPage() {
+  return (
+    <AppShell title="Progress">
+      <div className="rounded-md border border-zinc-700 bg-zinc-800 p-5 text-zinc-300">
+        Progress dashboard is coming next. This placeholder route is for app navigation in Issue #54.
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/src/app/workouts/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/workouts/sessions/[sessionId]/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
+import { AppShell } from '@/components/app-shell';
 
 type SessionDetails = {
   id: number;
@@ -34,7 +34,6 @@ export default function SessionPage() {
   const [error, setError] = useState<string | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
 
-  // local inputs per exercise
   const [repsBy, setRepsBy] = useState<Record<number, number>>({});
   const [weightBy, setWeightBy] = useState<Record<number, number>>({});
 
@@ -45,8 +44,8 @@ export default function SessionPage() {
       if (!token) throw new Error('Please login first (go to /)');
       const d = await apiFetch<SessionDetails>(`/workouts/sessions/${sessionId}/details`, { token });
       setDetails(d);
-    } catch (e: any) {
-      setError(e?.message ?? 'Failed to load session details');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load session details');
     }
   }
 
@@ -80,8 +79,8 @@ export default function SessionPage() {
       });
 
       await load();
-    } catch (e: any) {
-      setError(e?.message ?? 'Failed to add set');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to add set');
     } finally {
       setBusyKey(null);
     }
@@ -99,136 +98,128 @@ export default function SessionPage() {
       });
 
       router.push(`/workouts/sessions/${finished.id}/summary`);
-    } catch (e: any) {
-      setError(e?.message ?? 'Failed to finish session');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to finish session');
     }
   }
 
   return (
-    <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
-      <div className="max-w-3xl mx-auto space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold">Workout Session #{sessionId}</h1>
-          <div className="flex gap-2">
-            <Link
-              href="/programs"
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-            >
-              Back
-            </Link>
-            <button
-              onClick={load}
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-            >
-              Refresh
-            </button>
-            <button
-              onClick={finish}
-              className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white"
-            >
-              Finish
-            </button>
-          </div>
-        </div>
+    <AppShell
+      title={`Workout Session #${sessionId}`}
+      actions={
+        <>
+          <button
+            onClick={load}
+            className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
+          >
+            Refresh
+          </button>
+          <button
+            onClick={finish}
+            className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
+          >
+            Finish
+          </button>
+        </>
+      }
+    >
+      {error && <p className="text-sm text-red-400">{error}</p>}
 
-        {error && <p className="text-red-400 text-sm">{error}</p>}
-
-        {!details ? (
-          <p>Loading…</p>
-        ) : (
-          <div className="space-y-4">
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4">
-              <div className="font-semibold">{details.program.name}</div>
-              <div className="text-sm text-zinc-300">
-                {details.programDay.name} (Day {details.programDay.order})
-              </div>
-              <div className="text-xs text-zinc-400 mt-1">
-                Started: {new Date(details.startedAt).toLocaleString()}
-                {details.endedAt ? ` · Ended: ${new Date(details.endedAt).toLocaleString()}` : ''}
-              </div>
+      {!details ? (
+        <p>Loading...</p>
+      ) : (
+        <div className="space-y-4">
+          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
+            <div className="font-semibold">{details.program.name}</div>
+            <div className="text-sm text-zinc-300">
+              {details.programDay.name} (Day {details.programDay.order})
             </div>
+            <div className="mt-1 text-xs text-zinc-400">
+              Started: {new Date(details.startedAt).toLocaleString()}
+              {details.endedAt ? ` | Ended: ${new Date(details.endedAt).toLocaleString()}` : ''}
+            </div>
+          </div>
 
-            {details.exercises.map((block) => {
-              const de = block.dayExercise;
-              const performed = block.performedSets;
-              const busy = busyKey === `add-${de.id}`;
+          {details.exercises.map((block) => {
+            const de = block.dayExercise;
+            const performed = block.performedSets;
+            const busy = busyKey === `add-${de.id}`;
 
-              return (
-                <div
-                  key={de.id}
-                  className="rounded-md bg-zinc-800 border border-zinc-700 p-4 space-y-3"
-                >
-                  <div className="flex items-baseline justify-between">
-                    <div className="font-semibold">
-                      {de.order}. {de.exercise.name}
-                    </div>
-                    <div className="text-sm text-zinc-400">
-                      Target: {de.targetSets} sets · {de.minReps}-{de.maxReps} reps
-                    </div>
+            return (
+              <div
+                key={de.id}
+                className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4"
+              >
+                <div className="flex items-baseline justify-between">
+                  <div className="font-semibold">
+                    {de.order}. {de.exercise.name}
                   </div>
-
-                  <div className="space-y-1 text-sm">
-                    {performed.length === 0 ? (
-                      <div className="text-zinc-400">No sets yet</div>
-                    ) : (
-                      performed.map((s) => (
-                        <div key={`${de.id}-${s.setNumber}`} className="flex gap-3">
-                          <span className="text-zinc-400 w-14">Set {s.setNumber}</span>
-                          <span>{s.reps} reps</span>
-                          <span className="text-zinc-400">×</span>
-                          <span>{s.weight} kg</span>
-                        </div>
-                      ))
-                    )}
-                  </div>
-
-                  {/* Add set */}
-                  <div className="flex gap-2 items-end">
-                    <label className="flex flex-col gap-1">
-                      <span className="text-xs text-zinc-400">Reps</span>
-                      <input
-                        type="number"
-                        min={1}
-                        className="w-24 rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 outline-none"
-                        value={repsBy[de.id] ?? 8}
-                        onChange={(e) =>
-                          setRepsBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
-                        }
-                      />
-                    </label>
-
-                    <label className="flex flex-col gap-1">
-                      <span className="text-xs text-zinc-400">Weight (kg)</span>
-                      <input
-                        type="number"
-                        min={0}
-                        step={0.5}
-                        className="w-32 rounded-md bg-zinc-900 border border-zinc-700 px-3 py-2 outline-none"
-                        value={weightBy[de.id] ?? 0}
-                        onChange={(e) =>
-                          setWeightBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
-                        }
-                      />
-                    </label>
-
-                    <button
-                      disabled={busy || details.endedAt !== null}
-                      onClick={() => addSet(de.id, performed.length)}
-                      className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white disabled:opacity-50"
-                    >
-                      {details.endedAt
-                        ? 'Session finished'
-                        : busy
-                          ? 'Adding…'
-                          : `Add set ${performed.length + 1}`}
-                    </button>
+                  <div className="text-sm text-zinc-400">
+                    Target: {de.targetSets} sets | {de.minReps}-{de.maxReps} reps
                   </div>
                 </div>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    </main>
+
+                <div className="space-y-1 text-sm">
+                  {performed.length === 0 ? (
+                    <div className="text-zinc-400">No sets yet</div>
+                  ) : (
+                    performed.map((s) => (
+                      <div key={`${de.id}-${s.setNumber}`} className="flex gap-3">
+                        <span className="w-14 text-zinc-400">Set {s.setNumber}</span>
+                        <span>{s.reps} reps</span>
+                        <span className="text-zinc-400">x</span>
+                        <span>{s.weight} kg</span>
+                      </div>
+                    ))
+                  )}
+                </div>
+
+                <div className="flex items-end gap-2">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-zinc-400">Reps</span>
+                    <input
+                      type="number"
+                      min={1}
+                      className="w-24 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                      value={repsBy[de.id] ?? 8}
+                      onChange={(e) =>
+                        setRepsBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
+                      }
+                    />
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span className="text-xs text-zinc-400">Weight (kg)</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step={0.5}
+                      className="w-32 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                      value={weightBy[de.id] ?? 0}
+                      onChange={(e) =>
+                        setWeightBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
+                      }
+                    />
+                  </label>
+
+                  <button
+                    disabled={busy || details.endedAt !== null}
+                    onClick={() => addSet(de.id, performed.length)}
+                    className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
+                  >
+                    {details.endedAt
+                      ? 'Session finished'
+                      : busy
+                        ? 'Adding...'
+                        : `Add set ${performed.length + 1}`}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </AppShell>
   );
 }
+

--- a/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
+++ b/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { ArrowDown, ArrowUp, Minus, type LucideIcon } from 'lucide-react';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
+import { AppShell } from '@/components/app-shell';
 
 type MuscleGroup = string;
 
@@ -19,15 +20,12 @@ type BestE1rmSet = {
 
 type MuscleTotalsRow = {
   muscle: MuscleGroup;
-
   currentTotalSets: number;
   currentTotalReps: number;
   currentTotalVolume: number;
-
   previousTotalSets: number | null;
   previousTotalReps: number | null;
   previousTotalVolume: number | null;
-
   volumeDelta: number | null;
   volumeDeltaPct: number | null;
   hypertrophyProgress: ProgressState;
@@ -37,16 +35,13 @@ type SummaryExercise = {
   exerciseId: number;
   name: string;
   primaryMuscle: MuscleGroup;
-
   sets: number;
   repsTotal: number;
-
   currentVolume: number;
   previousVolume: number | null;
   volumeDelta: number | null;
   volumeDeltaPct: number | null;
   hypertrophyProgress: ProgressState;
-
   currentBestE1rmSet: BestE1rmSet;
   previousBestE1rmSet: BestE1rmSet;
   strengthProgress: ProgressState;
@@ -58,35 +53,56 @@ type Summary = {
   endedAt: string | null;
   durationSeconds: number | null;
   totals: { totalSets: number; totalReps: number; totalVolume: number };
-
-  // hypertrophy/workload signal
   muscleTotals: MuscleTotalsRow[];
-
-  // strength signal (per exercise)
   exercises: SummaryExercise[];
 };
 
+type ProgressMeta = {
+  Icon: LucideIcon;
+  colorClass: string;
+  label: string;
+};
+
+const PROGRESS_META: Record<ProgressState, ProgressMeta> = {
+  IMPROVED: { Icon: ArrowUp, colorClass: 'text-emerald-400', label: 'improved' },
+  SAME: { Icon: Minus, colorClass: 'text-yellow-400', label: 'same' },
+  REGRESSED: { Icon: ArrowDown, colorClass: 'text-red-400', label: 'regressed' },
+  NO_BASELINE: { Icon: Minus, colorClass: 'text-zinc-400', label: 'no baseline' },
+};
+
+function ProgressMark({ state }: { state: ProgressState }) {
+  const { Icon, colorClass, label } = PROGRESS_META[state];
+
+  return (
+    <span className={`mr-2 inline-flex ${colorClass}`} aria-label={label} title={label}>
+      <Icon className="h-4 w-4" />
+    </span>
+  );
+}
+
+function ProgressLegendItem({ state, text }: { state: ProgressState; text: string }) {
+  return (
+    <span className="inline-flex items-center">
+      <ProgressMark state={state} />
+      <span>{text}</span>
+    </span>
+  );
+}
+
 function formatDuration(seconds: number | null) {
-  if (seconds === null) return '—';
+  if (seconds === null) return '-';
   const m = Math.floor(seconds / 60);
   const s = seconds % 60;
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
-function dot(p: ProgressState) {
-  if (p === 'IMPROVED') return '🟢';
-  if (p === 'SAME') return '🟡';
-  if (p === 'REGRESSED') return '🔴';
-  return '⚪';
-}
-
 function formatBestE1rmSet(s: BestE1rmSet) {
-  if (!s) return '—';
-  return `${s.weight} × ${s.reps} (e1RM ${s.e1rm})`;
+  if (!s) return '-';
+  return `${s.weight} x ${s.reps} (e1RM ${s.e1rm})`;
 }
 
 function formatE1rmDelta(curr: BestE1rmSet, prev: BestE1rmSet) {
-  if (!curr || !prev) return '—';
+  if (!curr || !prev) return '-';
   const diff = curr.e1rm - prev.e1rm;
   if (Math.abs(diff) < 0.1) return '=';
   const sign = diff > 0 ? '+' : '';
@@ -94,7 +110,7 @@ function formatE1rmDelta(curr: BestE1rmSet, prev: BestE1rmSet) {
 }
 
 function formatPct(pct: number | null) {
-  if (pct === null || !Number.isFinite(pct)) return '—';
+  if (pct === null || !Number.isFinite(pct)) return '-';
   const sign = pct > 0 ? '+' : '';
   return `${sign}${pct.toFixed(1)}%`;
 }
@@ -113,8 +129,8 @@ export default function SessionSummaryPage() {
       if (!token) throw new Error('Please login first (go to /)');
       const s = await apiFetch<Summary>(`/workouts/sessions/${sessionId}/summary`, { token });
       setData(s);
-    } catch (e: any) {
-      setError(e?.message ?? 'Failed to load summary');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load summary');
     }
   }
 
@@ -135,169 +151,166 @@ export default function SessionSummaryPage() {
   }, [data]);
 
   return (
-    <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
-      <div className="max-w-3xl mx-auto space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-3xl font-bold">Summary — Session #{sessionId}</h1>
-          <div className="flex gap-2">
-            <button
-              onClick={load}
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-            >
-              Refresh
-            </button>
-            <Link
-              href="/home"
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-            >
-              Home
-            </Link>
+    <AppShell
+      title={`Summary - Session #${sessionId}`}
+      actions={
+        <button
+          onClick={load}
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
+        >
+          Refresh
+        </button>
+      }
+    >
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {!data ? (
+        <p>Loading...</p>
+      ) : (
+        <>
+          <div className="space-y-2 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+            <div className="flex items-baseline justify-between">
+              <div className="font-semibold">Workout totals</div>
+              <div className="text-sm text-zinc-300">Duration: {formatDuration(data.durationSeconds)}</div>
+            </div>
+
+            <div className="grid grid-cols-3 gap-3 text-sm">
+              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                <div className="text-xs text-zinc-400">Sets</div>
+                <div className="text-lg font-semibold">{data.totals.totalSets}</div>
+              </div>
+
+              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                <div className="text-xs text-zinc-400">Reps</div>
+                <div className="text-lg font-semibold">{data.totals.totalReps}</div>
+              </div>
+
+              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                <div className="text-xs text-zinc-400">Volume</div>
+                <div className="text-lg font-semibold">{Math.round(data.totals.totalVolume)}</div>
+              </div>
+            </div>
+
+            <div className="text-xs text-zinc-400">
+              Started: {new Date(data.startedAt).toLocaleString()}
+              {data.endedAt ? ` | Ended: ${new Date(data.endedAt).toLocaleString()}` : ''}
+            </div>
           </div>
-        </div>
 
-        {error && <p className="text-red-400 text-sm">{error}</p>}
+          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
+            <div className="mb-3 font-semibold">Muscle workload (hypertrophy signal)</div>
 
-        {!data ? (
-          <p>Loading…</p>
-        ) : (
-          <>
-            {/* Totals card */}
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4 space-y-2">
-              <div className="flex items-baseline justify-between">
-                <div className="font-semibold">Workout totals</div>
-                <div className="text-sm text-zinc-300">
-                  Duration: {formatDuration(data.durationSeconds)}
-                </div>
-              </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              {sortedMuscles.map((m) => (
+                <div key={m.muscle} className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                  <div className="flex items-baseline justify-between">
+                    <div className="font-semibold">
+                      <ProgressMark state={m.hypertrophyProgress} />
+                      {m.muscle}
+                    </div>
+                    <div className="text-xs text-zinc-400">
+                      {m.currentTotalSets} sets | {m.currentTotalReps} reps
+                    </div>
+                  </div>
 
-              <div className="grid grid-cols-3 gap-3 text-sm">
-                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
-                  <div className="text-zinc-400 text-xs">Sets</div>
-                  <div className="text-lg font-semibold">{data.totals.totalSets}</div>
-                </div>
+                  <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
+                    <div>
+                      <div className="text-xs text-zinc-400">Current volume</div>
+                      <div className="font-semibold">{Math.round(m.currentTotalVolume)}</div>
+                    </div>
 
-                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
-                  <div className="text-zinc-400 text-xs">Reps</div>
-                  <div className="text-lg font-semibold">{data.totals.totalReps}</div>
-                </div>
-
-                <div className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
-                  <div className="text-zinc-400 text-xs">Volume</div>
-                  <div className="text-lg font-semibold">{Math.round(data.totals.totalVolume)}</div>
-                </div>
-              </div>
-
-              <div className="text-xs text-zinc-400">
-                Started: {new Date(data.startedAt).toLocaleString()}
-                {data.endedAt ? ` · Ended: ${new Date(data.endedAt).toLocaleString()}` : ''}
-              </div>
-            </div>
-
-            {/* Hypertrophy / workload */}
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4">
-              <div className="font-semibold mb-3">Muscle workload (hypertrophy signal)</div>
-
-              <div className="grid grid-cols-2 gap-3">
-                {sortedMuscles.map((m) => (
-                  <div key={m.muscle} className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
-                    <div className="flex items-baseline justify-between">
+                    <div>
+                      <div className="text-xs text-zinc-400">Previous volume</div>
                       <div className="font-semibold">
-                        <span className="mr-2">{dot(m.hypertrophyProgress)}</span>
-                        {m.muscle}
-                      </div>
-                      <div className="text-xs text-zinc-400">
-                        {m.currentTotalSets} sets · {m.currentTotalReps} reps
+                        {m.previousTotalVolume === null ? '-' : Math.round(m.previousTotalVolume)}
                       </div>
                     </div>
 
-                    <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
-                      <div>
-                        <div className="text-zinc-400 text-xs">Current volume</div>
-                        <div className="font-semibold">{Math.round(m.currentTotalVolume)}</div>
-                      </div>
-
-                      <div>
-                        <div className="text-zinc-400 text-xs">Previous volume</div>
-                        <div className="font-semibold">
-                          {m.previousTotalVolume === null ? '—' : Math.round(m.previousTotalVolume)}
-                        </div>
-                      </div>
-
-                      <div>
-                        <div className="text-zinc-400 text-xs">Δ volume</div>
-                        <div className="font-semibold">
-                          {m.volumeDelta === null ? '—' : `${m.volumeDelta > 0 ? '+' : ''}${Math.round(m.volumeDelta)} (${formatPct(m.volumeDeltaPct)})`}
-                        </div>
+                    <div>
+                      <div className="text-xs text-zinc-400">Delta volume</div>
+                      <div className="font-semibold">
+                        {m.volumeDelta === null
+                          ? '-'
+                          : `${m.volumeDelta > 0 ? '+' : ''}${Math.round(m.volumeDelta)} (${formatPct(m.volumeDeltaPct)})`}
                       </div>
                     </div>
                   </div>
-                ))}
+                </div>
+              ))}
 
-                {sortedMuscles.length === 0 && (
-                  <div className="text-zinc-400 text-sm">No muscle totals for this session.</div>
-                )}
-              </div>
-
-              <div className="mt-3 text-xs text-zinc-400">
-                Legend: 🟢 improved · 🟡 same · 🔴 regressed · ⚪ no baseline
-              </div>
+              {sortedMuscles.length === 0 && (
+                <div className="text-sm text-zinc-400">No muscle totals for this session.</div>
+              )}
             </div>
 
-            {/* Strength signal */}
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-4">
-              <div className="font-semibold mb-3">Strength signal (e1RM)</div>
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-zinc-400">
+              <span>Legend:</span>
+              <ProgressLegendItem state="IMPROVED" text="improved" />
+              <ProgressLegendItem state="SAME" text="same" />
+              <ProgressLegendItem state="REGRESSED" text="regressed" />
+              <ProgressLegendItem state="NO_BASELINE" text="no baseline" />
+            </div>
+          </div>
 
-              <div className="space-y-3">
-                {sortedExercises.map((ex) => (
-                  <div key={ex.exerciseId} className="rounded-md bg-zinc-900 border border-zinc-700 p-3">
-                    <div className="flex items-baseline justify-between">
-                      <div className="font-semibold">
-                        <span className="mr-2">{dot(ex.strengthProgress)}</span>
-                        {ex.name} <span className="text-xs text-zinc-400">({ex.primaryMuscle})</span>
-                      </div>
+          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
+            <div className="mb-3 font-semibold">Strength signal (e1RM)</div>
 
-                      <div className="text-sm text-zinc-400">
-                        {ex.sets} sets · {ex.repsTotal} reps · vol {Math.round(ex.currentVolume)}
-                      </div>
+            <div className="space-y-3">
+              {sortedExercises.map((ex) => (
+                <div key={ex.exerciseId} className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                  <div className="flex items-baseline justify-between">
+                    <div className="font-semibold">
+                      <ProgressMark state={ex.strengthProgress} />
+                      {ex.name} <span className="text-xs text-zinc-400">({ex.primaryMuscle})</span>
                     </div>
 
-                    <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
-                      <div>
-                        <div className="text-zinc-400 text-xs">Current best e1RM</div>
-                        <div className="font-semibold">{formatBestE1rmSet(ex.currentBestE1rmSet)}</div>
-                      </div>
-
-                      <div>
-                        <div className="text-zinc-400 text-xs">Previous best e1RM</div>
-                        <div className="font-semibold">{formatBestE1rmSet(ex.previousBestE1rmSet)}</div>
-                      </div>
-
-                      <div>
-                        <div className="text-zinc-400 text-xs">Δ e1RM</div>
-                        <div className="font-semibold">{formatE1rmDelta(ex.currentBestE1rmSet, ex.previousBestE1rmSet)}</div>
-                      </div>
-                    </div>
-
-                    {/* Optional: hypertrophy line per exercise */}
-                    <div className="mt-2 text-xs text-zinc-400">
-                      Hypertrophy: <span className="mr-1">{dot(ex.hypertrophyProgress)}</span>
-                      Δ volume {ex.volumeDelta === null ? '—' : `${ex.volumeDelta > 0 ? '+' : ''}${Math.round(ex.volumeDelta)} (${formatPct(ex.volumeDeltaPct)})`}
+                    <div className="text-sm text-zinc-400">
+                      {ex.sets} sets | {ex.repsTotal} reps | vol {Math.round(ex.currentVolume)}
                     </div>
                   </div>
-                ))}
 
-                {sortedExercises.length === 0 && (
-                  <div className="text-zinc-400 text-sm">No performed sets in this session.</div>
-                )}
-              </div>
+                  <div className="mt-2 grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
+                    <div>
+                      <div className="text-xs text-zinc-400">Current best e1RM</div>
+                      <div className="font-semibold">{formatBestE1rmSet(ex.currentBestE1rmSet)}</div>
+                    </div>
 
-              <div className="mt-4 text-xs text-zinc-400">
-                Legend: 🟢 improved · 🟡 same · 🔴 regressed · ⚪ no baseline
-              </div>
+                    <div>
+                      <div className="text-xs text-zinc-400">Previous best e1RM</div>
+                      <div className="font-semibold">{formatBestE1rmSet(ex.previousBestE1rmSet)}</div>
+                    </div>
+
+                    <div>
+                      <div className="text-xs text-zinc-400">Delta e1RM</div>
+                      <div className="font-semibold">{formatE1rmDelta(ex.currentBestE1rmSet, ex.previousBestE1rmSet)}</div>
+                    </div>
+                  </div>
+
+                  <div className="mt-2 text-xs text-zinc-400">
+                    Hypertrophy: <ProgressMark state={ex.hypertrophyProgress} />
+                    Delta volume{' '}
+                    {ex.volumeDelta === null
+                      ? '-'
+                      : `${ex.volumeDelta > 0 ? '+' : ''}${Math.round(ex.volumeDelta)} (${formatPct(ex.volumeDeltaPct)})`}
+                  </div>
+                </div>
+              ))}
+
+              {sortedExercises.length === 0 && (
+                <div className="text-sm text-zinc-400">No performed sets in this session.</div>
+              )}
             </div>
-          </>
-        )}
-      </div>
-    </main>
+
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-zinc-400">
+              <span>Legend:</span>
+              <ProgressLegendItem state="IMPROVED" text="improved" />
+              <ProgressLegendItem state="SAME" text="same" />
+              <ProgressLegendItem state="REGRESSED" text="regressed" />
+              <ProgressLegendItem state="NO_BASELINE" text="no baseline" />
+            </div>
+          </div>
+        </>
+      )}
+    </AppShell>
   );
 }

--- a/apps/web/src/components/app-nav.tsx
+++ b/apps/web/src/components/app-nav.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+type NavItem = {
+  href: string;
+  label: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { href: '/home', label: 'Home' },
+  { href: '/programs', label: 'Programs' },
+  { href: '/progress', label: 'Progress' },
+];
+
+function isActive(pathname: string, href: string) {
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+function itemClass(active: boolean) {
+  return active
+    ? 'rounded-md border border-zinc-600 bg-zinc-700 px-3 py-2 text-sm font-semibold text-zinc-100'
+    : 'rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100';
+}
+
+export function AppNav() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      <nav className="sticky top-0 z-40 hidden border-b border-zinc-800 bg-zinc-900/95 backdrop-blur md:block">
+        <div className="mx-auto flex max-w-3xl items-center gap-2 px-6 py-3">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={itemClass(isActive(pathname, item.href))}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      </nav>
+
+      <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-800 bg-zinc-900/95 px-4 py-3 backdrop-blur md:hidden">
+        <div className="mx-auto grid max-w-3xl grid-cols-3 gap-2">
+          {NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={itemClass(isActive(pathname, item.href))}
+            >
+              <span className="block text-center">{item.label}</span>
+            </Link>
+          ))}
+        </div>
+      </nav>
+    </>
+  );
+}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { AppNav } from './app-nav';
+
+type AppShellProps = {
+  title: string;
+  actions?: ReactNode;
+  children: ReactNode;
+};
+
+export function AppShell({ title, actions, children }: AppShellProps) {
+  return (
+    <main className="min-h-screen bg-zinc-900 text-zinc-100">
+      <AppNav />
+
+      <div className="px-4 py-6 pb-24 md:px-6 md:py-8 md:pb-10">
+        <div className="mx-auto max-w-3xl space-y-6">
+          <div className="flex items-center justify-between gap-3">
+            <h1 className="text-3xl font-bold md:text-4xl">{title}</h1>
+            {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+          </div>
+
+          {children}
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## What
Add a shared responsive app navigation system and unify session-summary progress indicators with icon components.

## Why
Navigation was inconsistent across pages and Phase 1 UX still required mobile-first primary navigation.  
Summary progress markers also had rendering issues with text symbols, so they were moved to icon-based status marks for reliability and clarity.

## Scope
- Add shared app shell and navigation components:
  - desktop/tablet top nav
  - mobile bottom nav
  - active route state styling
- Refactor main in-app pages to use shared shell/nav:
  - Home
  - Programs
  - Workout session
  - Session summary
- Add `/progress` placeholder route as a valid navigation target
- Replace summary progress text symbols with `lucide-react` icon-based `ProgressMark`:
  - `ArrowUp` (improved)
  - `ArrowDown` (regressed)
  - `Minus` (same / no baseline with distinct colors)
- Reuse the same `ProgressMark` in legends and data rows

## Out of scope
- New backend/API behavior
- Progress engine logic changes
- Program versioning / rolling windows
- Full progress dashboard implementation

## Implementation details
- New shared components:
  - `apps/web/src/components/app-shell.tsx`
  - `apps/web/src/components/app-nav.tsx`
- New page:
  - `apps/web/src/app/progress/page.tsx`
- Updated pages:
  - `apps/web/src/app/home/page.tsx`
  - `apps/web/src/app/programs/page.tsx`
  - `apps/web/src/app/workouts/sessions/[sessionId]/page.tsx`
  - `apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx`
- Added dependency:
  - `lucide-react` (`apps/web/package.json`, lockfile updated)
- API contract unchanged

## How to test
1. Run web app and log in via dev login.
2. Verify navigation behavior:
   - desktop/tablet: top nav visible, bottom nav hidden
   - mobile viewport: bottom nav visible/fixed, top nav hidden
3. Navigate between `Home`, `Programs`, and `Progress`; confirm active state updates.
4. Open a workout session summary and verify:
   - progress marks render as icons (not `?` or escaped unicode text)
   - colors map correctly:
     - improved: green up arrow
     - same: yellow minus
     - regressed: red down arrow
     - no baseline: neutral minus
   - legend uses the same icon component style
5. Run lint in web:
   - `npm run lint` (expect no errors; only pre-existing warnings in `app/page.tsx`)

## Notes
This PR closes the remaining navigation gap in Phase 1 UX and keeps route pages focused on page logic while reusing shared layout/navigation components.

## Closes
Closes #54
