### PR TITLE
Add program management UI and active-program invariant

### DIFF
--- a/apps/api/src/modules/programs/programs.service.ts
+++ b/apps/api/src/modules/programs/programs.service.ts
@@ -8,29 +8,43 @@ import { UpdateProgramDto } from './dto/update-program.dto';
 export class ProgramsService {
   constructor(private readonly prisma: PrismaService) {}
 
+  private readonly baseSelect = {
+    id: true,
+    name: true,
+    type: true,
+    isActive: true,
+    createdAt: true,
+    updatedAt: true,
+  } as const;
+
   async create(userId: number, dto: CreateProgramDto) {
-    return this.prisma.program.create({
-      data: {
-        userId,
-        name: dto.name,
-        type: dto.type,
-        isActive: dto.isActive ?? false,
-      },
-      select: {
-        id: true,
-        name: true,
-        type: true,
-        isActive: true,
-        createdAt: true,
-      },
+    const shouldBeActive = dto.isActive ?? false;
+
+    return this.prisma.$transaction(async (tx) => {
+      if (shouldBeActive) {
+        await tx.program.updateMany({
+          where: { userId, isActive: true },
+          data: { isActive: false },
+        });
+      }
+
+      return tx.program.create({
+        data: {
+          userId,
+          name: dto.name,
+          type: dto.type,
+          isActive: shouldBeActive,
+        },
+        select: this.baseSelect,
+      });
     });
   }
 
   async findAll(userId: number) {
     return this.prisma.program.findMany({
       where: { userId },
-      orderBy: { createdAt: 'desc' },
-      select: { id: true, name: true, type: true, isActive: true },
+      orderBy: [{ isActive: 'desc' }, { createdAt: 'desc' }],
+      select: this.baseSelect,
     });
   }
 
@@ -76,24 +90,37 @@ export class ProgramsService {
   }
 
   async update(userId: number, id: number, dto: UpdateProgramDto) {
-    // whitelist only (never allow userId ownership changes)
-    const data: Prisma.ProgramUpdateManyMutationInput = {
+    const exists = await this.prisma.program.findFirst({
+      where: { id, userId },
+      select: { id: true },
+    });
+
+    if (!exists) throw new NotFoundException('Program not found');
+
+    const data: Prisma.ProgramUpdateInput = {
       ...(dto.name !== undefined ? { name: dto.name } : {}),
       ...(dto.type !== undefined ? { type: dto.type } : {}),
       ...(dto.isActive !== undefined ? { isActive: dto.isActive } : {}),
     };
 
-    const res = await this.prisma.program.updateMany({
-      where: { id, userId },
-      data,
-    });
+    return this.prisma.$transaction(async (tx) => {
+      if (dto.isActive === true) {
+        await tx.program.updateMany({
+          where: { userId, isActive: true, id: { not: id } },
+          data: { isActive: false },
+        });
+      }
 
-    if (res.count === 0) throw new NotFoundException('Program not found');
+      await tx.program.update({
+        where: { id },
+        data,
+        select: { id: true },
+      });
 
-    // return a clean read shape (avoid leaking raw entity if you prefer)
-    return this.prisma.program.findFirst({
-      where: { id, userId },
-      select: { id: true, name: true, type: true, isActive: true, createdAt: true, updatedAt: true },
+      return tx.program.findFirst({
+        where: { id, userId },
+        select: this.baseSelect,
+      });
     });
   }
 

--- a/apps/web/src/app/programs/page.tsx
+++ b/apps/web/src/app/programs/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
@@ -14,15 +14,52 @@ type ActiveSession = {
   programDayId: number;
 } | null;
 
-export default function ProgramsStartResumePage() {
+type ProgramType = 'AB' | 'PPL' | 'FULL_BODY' | 'CUSTOM';
+
+type Program = {
+  id: number;
+  name: string;
+  type: ProgramType;
+  isActive: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type ProgramEditor = {
+  name: string;
+  type: ProgramType;
+  isActive: boolean;
+};
+
+const PROGRAM_TYPES: ProgramType[] = ['AB', 'PPL', 'FULL_BODY', 'CUSTOM'];
+
+function formatProgramType(type: ProgramType) {
+  if (type === 'FULL_BODY') return 'Full Body';
+  if (type === 'AB') return 'A/B';
+  return type;
+}
+
+export default function ProgramsPage() {
   const router = useRouter();
 
   const [loading, setLoading] = useState(true);
-  const [active, setActive] = useState<ActiveSession>(null);
+  const [saving, setSaving] = useState(false);
+  const [activeSession, setActiveSession] = useState<ActiveSession>(null);
+  const [programs, setPrograms] = useState<Program[]>([]);
+
   const [programDayId, setProgramDayId] = useState<number>(1);
   const [error, setError] = useState<string | null>(null);
 
-  async function loadActive() {
+  const [createName, setCreateName] = useState('');
+  const [createType, setCreateType] = useState<ProgramType>('CUSTOM');
+  const [createIsActive, setCreateIsActive] = useState(false);
+
+  const [editingProgramId, setEditingProgramId] = useState<number | null>(null);
+  const [editor, setEditor] = useState<ProgramEditor | null>(null);
+
+  const activeProgram = useMemo(() => programs.find((p) => p.isActive) ?? null, [programs]);
+
+  async function loadData() {
     setError(null);
     setLoading(true);
 
@@ -30,24 +67,27 @@ export default function ProgramsStartResumePage() {
       const token = getToken();
       if (!token) throw new Error('Please login first (go to /)');
 
-      const data = await apiFetch<{ session: ActiveSession }>('/workouts/sessions/active', {
-        token,
-      });
+      const [activeRes, programsRes] = await Promise.all([
+        apiFetch<{ session: ActiveSession }>('/workouts/sessions/active', { token }),
+        apiFetch<Program[]>('/programs', { token }),
+      ]);
 
-      setActive(data.session);
+      setActiveSession(activeRes.session);
+      setPrograms(programsRes);
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to load active session');
+      setError(e instanceof Error ? e.message : 'Failed to load programs page');
     } finally {
       setLoading(false);
     }
   }
 
   useEffect(() => {
-    loadActive();
+    loadData();
   }, []);
 
-  async function onStart() {
+  async function onStartWorkout() {
     setError(null);
+
     try {
       const token = getToken();
       if (!token) throw new Error('Please login first (go to /)');
@@ -58,87 +98,378 @@ export default function ProgramsStartResumePage() {
         body: JSON.stringify({ programDayId }),
       });
 
-      setActive(session);
+      setActiveSession(session);
       router.push(`/workouts/sessions/${session.id}`);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to start session');
-      await loadActive();
+      await loadData();
     }
   }
 
-  function onResume() {
-    if (!active?.id) return;
-    router.push(`/workouts/sessions/${active.id}`);
+  function onResumeWorkout() {
+    if (!activeSession?.id) return;
+    router.push(`/workouts/sessions/${activeSession.id}`);
+  }
+
+  async function onCreateProgram() {
+    const name = createName.trim();
+    if (!name) {
+      setError('Program name is required');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const created = await apiFetch<Program>('/programs', {
+        method: 'POST',
+        token,
+        body: JSON.stringify({
+          name,
+          type: createType,
+          isActive: createIsActive,
+        }),
+      });
+
+      setCreateName('');
+      setCreateType('CUSTOM');
+      setCreateIsActive(false);
+
+      if (created.isActive) {
+        setPrograms((prev) => [
+          created,
+          ...prev.filter((p) => p.id !== created.id).map((p) => ({ ...p, isActive: false })),
+        ]);
+      } else {
+        setPrograms((prev) => [created, ...prev]);
+      }
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to create program');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function beginEdit(program: Program) {
+    setEditingProgramId(program.id);
+    setEditor({
+      name: program.name,
+      type: program.type,
+      isActive: program.isActive,
+    });
+  }
+
+  function cancelEdit() {
+    setEditingProgramId(null);
+    setEditor(null);
+  }
+
+  async function saveEdit(programId: number) {
+    if (!editor) return;
+    const name = editor.name.trim();
+
+    if (!name) {
+      setError('Program name is required');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const updated = await apiFetch<Program>(`/programs/${programId}`, {
+        method: 'PATCH',
+        token,
+        body: JSON.stringify({
+          name,
+          type: editor.type,
+          isActive: editor.isActive,
+        }),
+      });
+
+      setPrograms((prev) => {
+        const mapped = prev.map((p) => (p.id === programId ? { ...p, ...updated } : p));
+        if (!updated.isActive) return mapped;
+        return mapped.map((p) => (p.id === programId ? p : { ...p, isActive: false }));
+      });
+
+      cancelEdit();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to update program');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function setProgramActive(programId: number) {
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      await apiFetch<Program>(`/programs/${programId}`, {
+        method: 'PATCH',
+        token,
+        body: JSON.stringify({ isActive: true }),
+      });
+
+      setPrograms((prev) => prev.map((p) => ({ ...p, isActive: p.id === programId })));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to set active program');
+    } finally {
+      setSaving(false);
+    }
   }
 
   return (
-    <AppShell title="Programs - Start/Resume">
+    <AppShell
+      title="Programs"
+      actions={
+        <button
+          className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
+          onClick={loadData}
+          disabled={loading || saving}
+        >
+          Refresh
+        </button>
+      }
+    >
       {error && <p className="text-sm text-red-400">{error}</p>}
 
       {loading ? (
         <p>Loading...</p>
       ) : (
-        <div className="space-y-4 rounded-md border border-zinc-700 bg-zinc-800 p-4">
-          <div>
-            <div className="mb-1 font-semibold">Active session</div>
-            {active ? (
-              <div className="text-sm text-zinc-200">
-                <div>ID: {active.id}</div>
-                <div>ProgramDay: {active.programDayId}</div>
-                <div>Started: {new Date(active.startedAt).toLocaleString()}</div>
+        <>
+          <section className="space-y-3 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Workout entrypoint</h2>
+              {activeProgram ? (
+                <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
+                  Active program: {activeProgram.name}
+                </span>
+              ) : (
+                <span className="rounded-full border border-zinc-600 px-3 py-1 text-xs text-zinc-300">No active program</span>
+              )}
+            </div>
+
+            {activeSession ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="text-sm text-zinc-300">
+                  Active session #{activeSession.id} started at {new Date(activeSession.startedAt).toLocaleString()}
+                </div>
+                <button
+                  className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-white"
+                  onClick={onResumeWorkout}
+                >
+                  Resume workout
+                </button>
               </div>
             ) : (
-              <div className="text-sm text-zinc-400">No active session</div>
-            )}
-          </div>
+              <div className="flex flex-wrap items-end gap-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-sm text-zinc-400">Program day id (temporary)</span>
+                  <input
+                    className="w-44 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                    type="number"
+                    min={1}
+                    value={programDayId}
+                    onChange={(e) => setProgramDayId(Number(e.target.value))}
+                  />
+                </label>
 
-          {!active ? (
-            <div className="flex items-end gap-3">
-              <label className="flex flex-col gap-1">
-                <span className="text-sm text-zinc-400">programDayId (temp)</span>
+                <button
+                  className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
+                  onClick={onStartWorkout}
+                  disabled={saving}
+                >
+                  Start workout
+                </button>
+              </div>
+            )}
+          </section>
+
+          <section className="space-y-4 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
+            <h2 className="text-xl font-semibold">Create program</h2>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <label className="flex flex-col gap-1 md:col-span-2">
+                <span className="text-sm text-zinc-400">Name</span>
                 <input
-                  className="w-40 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
-                  type="number"
-                  min={1}
-                  value={programDayId}
-                  onChange={(e) => setProgramDayId(Number(e.target.value))}
+                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                  value={createName}
+                  onChange={(e) => setCreateName(e.target.value)}
+                  placeholder="e.g. Hypertrophy Block"
                 />
               </label>
 
-              <button
-                className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
-                onClick={onStart}
-              >
-                Start workout
-              </button>
-
-              <button
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
-                onClick={loadActive}
-              >
-                Refresh
-              </button>
+              <label className="flex flex-col gap-1">
+                <span className="text-sm text-zinc-400">Type</span>
+                <select
+                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                  value={createType}
+                  onChange={(e) => setCreateType(e.target.value as ProgramType)}
+                >
+                  {PROGRAM_TYPES.map((type) => (
+                    <option key={type} value={type}>
+                      {formatProgramType(type)}
+                    </option>
+                  ))}
+                </select>
+              </label>
             </div>
-          ) : (
-            <div className="flex gap-3">
-              <button
-                className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
-                onClick={onResume}
-              >
-                Resume workout
-              </button>
 
-              <button
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
-                onClick={loadActive}
-              >
-                Refresh
-              </button>
-            </div>
-          )}
-        </div>
+            <label className="inline-flex items-center gap-2 text-sm text-zinc-300">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-zinc-600 bg-zinc-900"
+                checked={createIsActive}
+                onChange={(e) => setCreateIsActive(e.target.checked)}
+              />
+              Set as active program
+            </label>
+
+            <button
+              className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
+              onClick={onCreateProgram}
+              disabled={saving}
+            >
+              Create program
+            </button>
+          </section>
+
+          <section className="space-y-4 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
+            <h2 className="text-xl font-semibold">Your programs</h2>
+
+            {programs.length === 0 ? (
+              <p className="text-sm text-zinc-400">No programs yet. Create your first program above.</p>
+            ) : (
+              <div className="space-y-3">
+                {programs.map((program) => {
+                  const isEditing = editingProgramId === program.id && editor !== null;
+
+                  return (
+                    <article key={program.id} className="rounded-md border border-zinc-700 bg-zinc-900 p-4">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <h3 className="text-lg font-semibold">
+                              {isEditing ? editor.name : program.name}
+                            </h3>
+                            {program.isActive && (
+                              <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-300">
+                                Active
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-sm text-zinc-400">
+                            Type:{' '}
+                            <span className="text-zinc-200">
+                              {isEditing ? formatProgramType(editor.type) : formatProgramType(program.type)}
+                            </span>
+                          </p>
+                        </div>
+
+                        {isEditing ? (
+                          <div className="flex gap-2">
+                            <button
+                              className="rounded-md bg-zinc-100 px-3 py-2 text-sm font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
+                              onClick={() => saveEdit(program.id)}
+                              disabled={saving}
+                            >
+                              Save
+                            </button>
+                            <button
+                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm hover:bg-zinc-700"
+                              onClick={cancelEdit}
+                              disabled={saving}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        ) : (
+                          <div className="flex gap-2">
+                            <button
+                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm hover:bg-zinc-700"
+                              onClick={() => beginEdit(program)}
+                              disabled={saving}
+                            >
+                              Edit
+                            </button>
+                            {!program.isActive && (
+                              <button
+                                className="rounded-md border border-emerald-500/50 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 hover:bg-emerald-500/20"
+                                onClick={() => setProgramActive(program.id)}
+                                disabled={saving}
+                              >
+                                Set active
+                              </button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      {isEditing && (
+                        <div className="mt-4 grid gap-3 md:grid-cols-3">
+                          <label className="flex flex-col gap-1 md:col-span-2">
+                            <span className="text-sm text-zinc-400">Name</span>
+                            <input
+                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                              value={editor.name}
+                              onChange={(e) => setEditor((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
+                            />
+                          </label>
+
+                          <label className="flex flex-col gap-1">
+                            <span className="text-sm text-zinc-400">Type</span>
+                            <select
+                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                              value={editor.type}
+                              onChange={(e) =>
+                                setEditor((prev) =>
+                                  prev ? { ...prev, type: e.target.value as ProgramType } : prev,
+                                )
+                              }
+                            >
+                              {PROGRAM_TYPES.map((type) => (
+                                <option key={type} value={type}>
+                                  {formatProgramType(type)}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+
+                          <label className="inline-flex items-center gap-2 text-sm text-zinc-300 md:col-span-3">
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4 rounded border-zinc-600 bg-zinc-900"
+                              checked={editor.isActive}
+                              onChange={(e) =>
+                                setEditor((prev) =>
+                                  prev ? { ...prev, isActive: e.target.checked } : prev,
+                                )
+                              }
+                            />
+                            Set as active program
+                          </label>
+                        </div>
+                      )}
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        </>
       )}
     </AppShell>
   );
 }
-


### PR DESCRIPTION
## What
Add a full Programs management vertical slice:
- API invariant for active program selection
- Web UI to create, edit, and set active programs
- Preserve existing workout start/resume entrypoint in Programs page

## Why
Users were blocked to seeded programs and could not manage their own programs.  
This issue unlocks real user-owned program workflows and keeps active-program behavior consistent.

## Scope
- API (`ProgramsService`)
  - Enforce “one active program per user” when creating/updating with `isActive: true`
  - Keep ownership checks and not-found behavior
  - Return consistent program response shape
  - Order program list by active first, then newest
- Web (`/programs`)
  - Replace test-like screen with management UI
  - Add create program form (name/type/isActive)
  - Add edit program flow per card (name/type/isActive)
  - Add “Set active” quick action
  - Keep start/resume workout card and behavior

## Out of scope
- Program day/exercise builder
- Progress dashboard implementation
- Program versioning

## Implementation details
- Updated:
  - `apps/api/src/modules/programs/programs.service.ts`
- Updated:
  - `apps/web/src/app/programs/page.tsx`
- Active program invariant implemented in transactional API logic:
  - create with `isActive: true` deactivates other user programs first
  - update with `isActive: true` deactivates other user programs first
- Programs list now sorted by active first.

## How to test
1. Open `/programs` and create a new program.
2. Verify new program appears immediately.
3. Edit name/type on an existing program and save.
4. Set one program active and verify previous active is deactivated.
5. Verify start/resume workout flow still works from Programs page.
6. Run checks:
   - API build: `npm run build` in `apps/api`
   - Web lint: `npm run lint` in `apps/web`

## Notes
- API contract response shape is preserved for current web usage.
- Existing pre-existing web lint warnings in `apps/web/src/app/page.tsx` remain unchanged by this PR.

## Closes
Closes #56
