### PR TITLE
Add ProgramDays CRUD + reorder in Programs editor

### DIFF
--- a/apps/api/src/modules/program-days/dto/reorder-program-days.dto.ts
+++ b/apps/api/src/modules/program-days/dto/reorder-program-days.dto.ts
@@ -1,0 +1,18 @@
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsInt, ValidateNested } from 'class-validator';
+
+class ProgramDayOrderItemDto {
+  @IsInt()
+  id!: number;
+
+  @IsInt()
+  order!: number;
+}
+
+export class ReorderProgramDaysDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => ProgramDayOrderItemDto)
+  items!: ProgramDayOrderItemDto[];
+}

--- a/apps/api/src/modules/program-days/program-days.controller.ts
+++ b/apps/api/src/modules/program-days/program-days.controller.ts
@@ -12,6 +12,7 @@ import {
 import { ProgramDaysService } from './program-days.service';
 import { CreateProgramDayDto } from './dto/create-program-day.dto';
 import { UpdateProgramDayDto } from './dto/update-program-day.dto';
+import { ReorderProgramDaysDto } from './dto/reorder-program-days.dto';
 import { CurrentUserId } from '../../common/current-user-id.decorator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
@@ -55,6 +56,15 @@ export class ProgramDaysController {
     @Body() dto: UpdateProgramDayDto,
   ) {
     return this.programDaysService.update(userId, programId, dayId, dto);
+  }
+
+  @Post('reorder')
+  reorder(
+    @CurrentUserId() userId: number,
+    @Param('programId', ParseIntPipe) programId: number,
+    @Body() dto: ReorderProgramDaysDto,
+  ) {
+    return this.programDaysService.reorder(userId, programId, dto);
   }
 
   @Delete(':dayId')

--- a/apps/api/src/modules/program-days/program-days.service.ts
+++ b/apps/api/src/modules/program-days/program-days.service.ts
@@ -1,12 +1,43 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Prisma, ProgramDay } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateProgramDayDto } from './dto/create-program-day.dto';
 import { UpdateProgramDayDto } from './dto/update-program-day.dto';
+import { ReorderProgramDaysDto } from './dto/reorder-program-days.dto';
 
 @Injectable()
 export class ProgramDaysService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private readonly programDayOwnershipWhere = (userId: number, programId: number) => ({
+    programId,
+    program: { userId },
+  });
+
+  private async normalizeDayOrders(
+    tx: Prisma.TransactionClient,
+    userId: number,
+    programId: number,
+  ): Promise<void> {
+    const rows = await tx.programDay.findMany({
+      where: this.programDayOwnershipWhere(userId, programId),
+      select: { id: true },
+      orderBy: [{ order: 'asc' }, { id: 'asc' }],
+    });
+
+    for (let index = 0; index < rows.length; index += 1) {
+      const expectedOrder = index + 1;
+      await tx.programDay.update({
+        where: { id: rows[index].id },
+        data: { order: expectedOrder },
+      });
+    }
+  }
 
   private async ensureProgramOwnership(userId: number, programId: number): Promise<void> {
     const program = await this.prisma.program.findFirst({
@@ -41,10 +72,7 @@ export class ProgramDaysService {
     await this.ensureProgramOwnership(userId, programId);
 
     return this.prisma.programDay.findMany({
-      where: {
-        programId,
-        program: { userId },
-      },
+      where: this.programDayOwnershipWhere(userId, programId),
       orderBy: { order: 'asc' },
     });
   }
@@ -53,11 +81,7 @@ export class ProgramDaysService {
     await this.ensureProgramOwnership(userId, programId);
 
     const day = await this.prisma.programDay.findFirst({
-      where: {
-        id: dayId,
-        programId,
-        program: { userId },
-      },
+      where: { id: dayId, ...this.programDayOwnershipWhere(userId, programId) },
     });
 
     if (!day) throw new NotFoundException('Program day not found');
@@ -80,11 +104,7 @@ export class ProgramDaysService {
 
     try {
       const res = await this.prisma.programDay.updateMany({
-        where: {
-          id: dayId,
-          programId,
-          program: { userId },
-        },
+        where: { id: dayId, ...this.programDayOwnershipWhere(userId, programId) },
         data,
       });
 
@@ -92,11 +112,7 @@ export class ProgramDaysService {
 
       // return updated row
       const updated = await this.prisma.programDay.findFirst({
-        where: {
-          id: dayId,
-          programId,
-          program: { userId },
-        },
+        where: { id: dayId, ...this.programDayOwnershipWhere(userId, programId) },
       });
 
       if (!updated) throw new NotFoundException('Program day not found');
@@ -109,17 +125,86 @@ export class ProgramDaysService {
     }
   }
 
+  async reorder(userId: number, programId: number, dto: ReorderProgramDaysDto): Promise<ProgramDay[]> {
+    await this.ensureProgramOwnership(userId, programId);
+
+    const existingDays = await this.prisma.programDay.findMany({
+      where: this.programDayOwnershipWhere(userId, programId),
+      select: { id: true },
+      orderBy: { order: 'asc' },
+    });
+
+    if (existingDays.length !== dto.items.length) {
+      throw new BadRequestException('Reorder payload must include all program days exactly once');
+    }
+
+    const existingIds = new Set(existingDays.map((d) => d.id));
+    const itemIds = dto.items.map((item) => item.id);
+    const uniqueItemIds = new Set(itemIds);
+
+    if (uniqueItemIds.size !== dto.items.length) {
+      throw new BadRequestException('Program day ids must be unique');
+    }
+
+    for (const id of uniqueItemIds) {
+      if (!existingIds.has(id)) {
+        throw new BadRequestException('Reorder payload contains day ids outside the program');
+      }
+    }
+
+    const uniqueOrders = new Set(dto.items.map((item) => item.order));
+    if (uniqueOrders.size !== dto.items.length) {
+      throw new BadRequestException('Program day orders must be unique');
+    }
+
+    const sortedOrders = [...uniqueOrders].sort((a, b) => a - b);
+    for (let index = 0; index < sortedOrders.length; index += 1) {
+      if (sortedOrders[index] !== index + 1) {
+        throw new BadRequestException('Program day orders must be contiguous and start at 1');
+      }
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const tempOffset = dto.items.length + 1000;
+
+      for (const item of dto.items) {
+        await tx.programDay.updateMany({
+          where: { id: item.id, ...this.programDayOwnershipWhere(userId, programId) },
+          data: { order: item.order + tempOffset },
+        });
+      }
+
+      for (const item of dto.items) {
+        await tx.programDay.updateMany({
+          where: { id: item.id, ...this.programDayOwnershipWhere(userId, programId) },
+          data: { order: item.order },
+        });
+      }
+    });
+
+    return this.findAll(userId, programId);
+  }
+
   async remove(userId: number, programId: number, dayId: number): Promise<void> {
     await this.ensureProgramOwnership(userId, programId);
 
-    const res = await this.prisma.programDay.deleteMany({
-      where: {
-        id: dayId,
-        programId,
-        program: { userId },
-      },
-    });
+    try {
+      await this.prisma.$transaction(async (tx) => {
+        const res = await tx.programDay.deleteMany({
+          where: { id: dayId, ...this.programDayOwnershipWhere(userId, programId) },
+        });
 
-    if (res.count === 0) throw new NotFoundException('Program day not found');
+        if (res.count === 0) throw new NotFoundException('Program day not found');
+
+        await this.normalizeDayOrders(tx, userId, programId);
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2003') {
+        throw new ConflictException(
+          'Cannot delete a program day that has linked exercises or workout history',
+        );
+      }
+      throw e;
+    }
   }
 }

--- a/apps/web/src/app/programs/page.tsx
+++ b/apps/web/src/app/programs/page.tsx
@@ -40,6 +40,11 @@ type ProgramEditor = {
   isActive: boolean;
 };
 
+type ProgramDayEditor = {
+  draftNameByDayId: Record<number, string>;
+  newDayName: string;
+};
+
 const PROGRAM_TYPES: ProgramType[] = ['AB', 'PPL', 'FULL_BODY', 'CUSTOM'];
 
 function formatProgramType(type: ProgramType) {
@@ -69,6 +74,7 @@ export default function ProgramsPage() {
 
   const [editingProgramId, setEditingProgramId] = useState<number | null>(null);
   const [editor, setEditor] = useState<ProgramEditor | null>(null);
+  const [dayEditor, setDayEditor] = useState<ProgramDayEditor | null>(null);
 
   const activeProgram = useMemo(() => programs.find((p) => p.isActive) ?? null, [programs]);
 
@@ -195,11 +201,155 @@ export default function ProgramsPage() {
       type: program.type,
       isActive: program.isActive,
     });
+    setDayEditor({
+      draftNameByDayId: Object.fromEntries(program.days.map((day) => [day.id, day.name])),
+      newDayName: '',
+    });
   }
 
   function cancelEdit() {
     setEditingProgramId(null);
     setEditor(null);
+    setDayEditor(null);
+  }
+
+  function setProgramDays(programId: number, days: ProgramDay[]) {
+    const normalizedDays = [...days].sort((a, b) => a.order - b.order);
+    setPrograms((prev) => prev.map((p) => (p.id === programId ? { ...p, days: normalizedDays } : p)));
+    setDayEditor((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        draftNameByDayId: Object.fromEntries(normalizedDays.map((day) => [day.id, day.name])),
+      };
+    });
+  }
+
+  async function createProgramDay(programId: number) {
+    if (!dayEditor) return;
+    const name = dayEditor.newDayName.trim();
+    if (!name) {
+      setError('Program day name is required');
+      return;
+    }
+
+    const program = programs.find((p) => p.id === programId);
+    if (!program) return;
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const nextOrder = program.days.length + 1;
+      const created = await apiFetch<ProgramDay>(`/programs/${programId}/days`, {
+        method: 'POST',
+        token,
+        body: JSON.stringify({ name, order: nextOrder }),
+      });
+
+      setProgramDays(programId, [...program.days, created]);
+      setDayEditor((prev) => (prev ? { ...prev, newDayName: '' } : prev));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to create program day');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function renameProgramDay(programId: number, dayId: number) {
+    if (!dayEditor) return;
+    const name = dayEditor.draftNameByDayId[dayId]?.trim();
+    if (!name) {
+      setError('Program day name is required');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const updated = await apiFetch<ProgramDay>(`/programs/${programId}/days/${dayId}`, {
+        method: 'PATCH',
+        token,
+        body: JSON.stringify({ name }),
+      });
+
+      const program = programs.find((p) => p.id === programId);
+      if (!program) return;
+      setProgramDays(
+        programId,
+        program.days.map((day) => (day.id === dayId ? { ...day, name: updated.name } : day)),
+      );
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to rename program day');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteProgramDay(programId: number, dayId: number) {
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      await apiFetch<{ ok: true }>(`/programs/${programId}/days/${dayId}`, {
+        method: 'DELETE',
+        token,
+      });
+
+      const nextDays = await apiFetch<ProgramDay[]>(`/programs/${programId}/days`, { token });
+      setProgramDays(programId, nextDays);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to delete program day');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function moveProgramDay(programId: number, dayId: number, direction: -1 | 1) {
+    const program = programs.find((p) => p.id === programId);
+    if (!program) return;
+
+    const sortedDays = [...program.days].sort((a, b) => a.order - b.order);
+    const currentIndex = sortedDays.findIndex((day) => day.id === dayId);
+    if (currentIndex === -1) return;
+
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= sortedDays.length) return;
+
+    const reordered = [...sortedDays];
+    const [moved] = reordered.splice(currentIndex, 1);
+    reordered.splice(nextIndex, 0, moved);
+
+    const payload = reordered.map((day, index) => ({ id: day.id, order: index + 1 }));
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const nextDays = await apiFetch<ProgramDay[]>(`/programs/${programId}/days/reorder`, {
+        method: 'POST',
+        token,
+        body: JSON.stringify({ items: payload }),
+      });
+      setProgramDays(programId, nextDays);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to reorder program days');
+    } finally {
+      setSaving(false);
+    }
   }
 
   async function saveEdit(programId: number) {
@@ -479,50 +629,146 @@ export default function ProgramsPage() {
                       </div>
 
                       {isEditing && (
-                        <div className="mt-4 grid gap-3 md:grid-cols-3">
-                          <label className="flex flex-col gap-1 md:col-span-2">
-                            <span className="text-sm text-zinc-400">Name</span>
-                            <input
-                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
-                              value={editor.name}
-                              onChange={(e) =>
-                                setEditor((prev) => (prev ? { ...prev, name: e.target.value } : prev))
-                              }
-                            />
-                          </label>
+                        <div className="mt-4 space-y-5">
+                          <div className="grid gap-3 md:grid-cols-3">
+                            <label className="flex flex-col gap-1 md:col-span-2">
+                              <span className="text-sm text-zinc-400">Name</span>
+                              <input
+                                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                                value={editor.name}
+                                onChange={(e) =>
+                                  setEditor((prev) => (prev ? { ...prev, name: e.target.value } : prev))
+                                }
+                              />
+                            </label>
 
-                          <label className="flex flex-col gap-1">
-                            <span className="text-sm text-zinc-400">Type</span>
-                            <select
-                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
-                              value={editor.type}
-                              onChange={(e) =>
-                                setEditor((prev) =>
-                                  prev ? { ...prev, type: e.target.value as ProgramType } : prev,
-                                )
-                              }
-                            >
-                              {PROGRAM_TYPES.map((type) => (
-                                <option key={type} value={type}>
-                                  {formatProgramType(type)}
-                                </option>
-                              ))}
-                            </select>
-                          </label>
+                            <label className="flex flex-col gap-1">
+                              <span className="text-sm text-zinc-400">Type</span>
+                              <select
+                                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                                value={editor.type}
+                                onChange={(e) =>
+                                  setEditor((prev) =>
+                                    prev ? { ...prev, type: e.target.value as ProgramType } : prev,
+                                  )
+                                }
+                              >
+                                {PROGRAM_TYPES.map((type) => (
+                                  <option key={type} value={type}>
+                                    {formatProgramType(type)}
+                                  </option>
+                                ))}
+                              </select>
+                            </label>
 
-                          <label className="inline-flex items-center gap-2 text-sm text-zinc-300 md:col-span-3">
-                            <input
-                              type="checkbox"
-                              className="h-4 w-4 rounded border-zinc-600 bg-zinc-900"
-                              checked={editor.isActive}
-                              onChange={(e) =>
-                                setEditor((prev) =>
-                                  prev ? { ...prev, isActive: e.target.checked } : prev,
-                                )
-                              }
-                            />
-                            Set as active program
-                          </label>
+                            <label className="inline-flex items-center gap-2 text-sm text-zinc-300 md:col-span-3">
+                              <input
+                                type="checkbox"
+                                className="h-4 w-4 rounded border-zinc-600 bg-zinc-900"
+                                checked={editor.isActive}
+                                onChange={(e) =>
+                                  setEditor((prev) =>
+                                    prev ? { ...prev, isActive: e.target.checked } : prev,
+                                  )
+                                }
+                              />
+                              Set as active program
+                            </label>
+                          </div>
+
+                          <div className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+                            <h4 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">
+                              ProgramDays
+                            </h4>
+
+                            <div className="flex flex-wrap items-end gap-2">
+                              <label className="flex min-w-[220px] flex-1 flex-col gap-1">
+                                <span className="text-sm text-zinc-400">New day name</span>
+                                <input
+                                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                  value={dayEditor?.newDayName ?? ''}
+                                  onChange={(e) =>
+                                    setDayEditor((prev) =>
+                                      prev ? { ...prev, newDayName: e.target.value } : prev,
+                                    )
+                                  }
+                                  placeholder="e.g. Lower A"
+                                />
+                              </label>
+                              <button
+                                className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm hover:bg-zinc-700 disabled:opacity-50"
+                                onClick={() => createProgramDay(program.id)}
+                                disabled={saving}
+                              >
+                                Add day
+                              </button>
+                            </div>
+
+                            {program.days.length === 0 ? (
+                              <p className="text-sm text-zinc-400">No days yet.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                {program.days
+                                  .slice()
+                                  .sort((a, b) => a.order - b.order)
+                                  .map((day, index, arr) => (
+                                    <div
+                                      key={day.id}
+                                      className="grid gap-2 rounded-md border border-zinc-700 bg-zinc-900 p-3 md:grid-cols-[80px,1fr,auto]"
+                                    >
+                                      <div className="text-sm text-zinc-400">#{day.order}</div>
+                                      <input
+                                        className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm outline-none"
+                                        value={dayEditor?.draftNameByDayId[day.id] ?? day.name}
+                                        onChange={(e) =>
+                                          setDayEditor((prev) =>
+                                            prev
+                                              ? {
+                                                  ...prev,
+                                                  draftNameByDayId: {
+                                                    ...prev.draftNameByDayId,
+                                                    [day.id]: e.target.value,
+                                                  },
+                                                }
+                                              : prev,
+                                          )
+                                        }
+                                      />
+                                      <div className="flex flex-wrap gap-2">
+                                        <button
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          onClick={() => moveProgramDay(program.id, day.id, -1)}
+                                          disabled={saving || index === 0}
+                                        >
+                                          Up
+                                        </button>
+                                        <button
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          onClick={() => moveProgramDay(program.id, day.id, 1)}
+                                          disabled={saving || index === arr.length - 1}
+                                        >
+                                          Down
+                                        </button>
+                                        <button
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          onClick={() => renameProgramDay(program.id, day.id)}
+                                          disabled={saving}
+                                        >
+                                          Rename
+                                        </button>
+                                        <button
+                                          className="rounded-md border border-red-500/50 bg-red-500/10 px-2 py-1 text-xs text-red-200 hover:bg-red-500/20 disabled:opacity-50"
+                                          onClick={() => deleteProgramDay(program.id, day.id)}
+                                          disabled={saving}
+                                        >
+                                          Delete
+                                        </button>
+                                      </div>
+                                    </div>
+                                  ))}
+                              </div>
+                            )}
+                          </div>
                         </div>
                       )}
                     </article>


### PR DESCRIPTION
## What
- Added ProgramDays management in Programs editor UI:
  - add day
  - rename day
  - delete day
  - reorder (up/down)
- Added API endpoint: `POST /programs/:programId/days/reorder`
- Added reorder DTO validation for payload shape.
- Hardened ProgramDay service behavior:
  - reorder payload must include all days exactly once
  - order values must be unique, contiguous, and start at 1
  - transactional reorder to avoid unique-order collisions
  - delete now normalizes remaining day order
  - delete returns conflict when linked records prevent removal

## Why
- Supports Programs UX Overhaul Part 1 and enables production-ready day management.
- Prevents fragile reorder behavior caused by direct order patch collisions.

## Scope
- `apps/web/src/app/programs/page.tsx`
- `apps/api/src/modules/program-days/program-days.controller.ts`
- `apps/api/src/modules/program-days/program-days.service.ts`
- `apps/api/src/modules/program-days/dto/reorder-program-days.dto.ts`
- `.internal-docs/API_CONTRACT.md`

## Out of scope
- DayExercises CRUD/reorder/targets (Part 2).
- Program versioning and progress logic changes.

## Implementation details
- Reorder uses a two-phase transactional update with temporary offset to preserve unique `(programId, order)` constraints.
- ProgramDays UI updates local state from API responses to keep order/name consistent.
- Existing ownership checks and JWT guard patterns are preserved.

## How to test
1. Open `/programs`, edit a program.
2. Add multiple days and verify sequential order.
3. Rename a day and verify persistence after refresh.
4. Move days up/down and verify persisted order after refresh.
5. Delete a day and verify remaining days are re-numbered from 1.
6. Confirm start-workout dropdown reflects updated active program day order.
7. Run:
   - `npm run build` in `apps/api`
   - `npm run build` in `apps/web`

## Notes
- `apps/web` lint currently shows pre-existing warnings in `apps/web/src/app/page.tsx` (not introduced by this PR).

## Closes
Closes #60
