### PR TITLE
Add Program editor Part 2 with DayExercises CRUD and target editing

### DIFF
--- a/apps/api/src/modules/day-exercises/day-exercises.controller.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.controller.ts
@@ -13,6 +13,7 @@ import { CurrentUserId } from '../../common/current-user-id.decorator';
 import { DayExercisesService } from './day-exercises.service';
 import { CreateDayExerciseDto } from './dto/create-day-exercise.dto';
 import { UpdateDayExerciseDto } from './dto/update-day-exercise.dto';
+import { ReorderDayExercisesDto } from './dto/reorder-day-exercises.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @UseGuards(JwtAuthGuard)
@@ -46,7 +47,12 @@ export class DayExercisesController {
     @Param('dayId', ParseIntPipe) dayId: number,
     @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
   ) {
-    return this.dayExercisesService.findOne(userId, programId, dayId, dayExerciseId);
+    return this.dayExercisesService.findOne(
+      userId,
+      programId,
+      dayId,
+      dayExerciseId,
+    );
   }
 
   @Patch(':dayExerciseId')
@@ -57,7 +63,23 @@ export class DayExercisesController {
     @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
     @Body() dto: UpdateDayExerciseDto,
   ) {
-    return this.dayExercisesService.update(userId, programId, dayId, dayExerciseId, dto);
+    return this.dayExercisesService.update(
+      userId,
+      programId,
+      dayId,
+      dayExerciseId,
+      dto,
+    );
+  }
+
+  @Post('reorder')
+  reorder(
+    @CurrentUserId() userId: number,
+    @Param('programId', ParseIntPipe) programId: number,
+    @Param('dayId', ParseIntPipe) dayId: number,
+    @Body() dto: ReorderDayExercisesDto,
+  ) {
+    return this.dayExercisesService.reorder(userId, programId, dayId, dto);
   }
 
   @Delete(':dayExerciseId')
@@ -67,7 +89,12 @@ export class DayExercisesController {
     @Param('dayId', ParseIntPipe) dayId: number,
     @Param('dayExerciseId', ParseIntPipe) dayExerciseId: number,
   ) {
-    await this.dayExercisesService.remove(userId, programId, dayId, dayExerciseId);
+    await this.dayExercisesService.remove(
+      userId,
+      programId,
+      dayId,
+      dayExerciseId,
+    );
     return { ok: true };
   }
 }

--- a/apps/api/src/modules/day-exercises/day-exercises.service.ts
+++ b/apps/api/src/modules/day-exercises/day-exercises.service.ts
@@ -8,10 +8,20 @@ import { DayExercise, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateDayExerciseDto } from './dto/create-day-exercise.dto';
 import { UpdateDayExerciseDto } from './dto/update-day-exercise.dto';
+import { ReorderDayExercisesDto } from './dto/reorder-day-exercises.dto';
 
 @Injectable()
 export class DayExercisesService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private readonly dayOwnershipWhere = (
+    userId: number,
+    programId: number,
+    dayId: number,
+  ) => ({
+    programDayId: dayId,
+    programDay: { programId, program: { userId } },
+  });
 
   private validateRepRange(minReps?: number, maxReps?: number) {
     if (minReps !== undefined && maxReps !== undefined && minReps > maxReps) {
@@ -19,7 +29,11 @@ export class DayExercisesService {
     }
   }
 
-  private async ensureDayOwnership(userId: number, programId: number, dayId: number) {
+  private async ensureDayOwnership(
+    userId: number,
+    programId: number,
+    dayId: number,
+  ) {
     // מאמתים גם programId וגם dayId וגם שהכל שייך ל-user
     const day = await this.prisma.programDay.findFirst({
       where: {
@@ -33,7 +47,10 @@ export class DayExercisesService {
     if (!day) throw new NotFoundException('Program day not found');
   }
 
-  private async ensureExerciseVisibleToUser(userId: number, exerciseId: number) {
+  private async ensureExerciseVisibleToUser(
+    userId: number,
+    exerciseId: number,
+  ) {
     // בינתיים: אם עוד לא הוספת exercise.userId, תשאיר findUnique רגיל.
     // אחרי שתוסיף userId nullable, מחליפים את זה ל:
     // where: { id: exerciseId, OR: [{ userId: null }, { userId }] }
@@ -67,21 +84,27 @@ export class DayExercisesService {
         },
       });
     } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-        throw new ConflictException('Exercise order already exists for this day');
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'Exercise order already exists for this day',
+        );
       }
       throw e;
     }
   }
 
-  async findAll(userId: number, programId: number, dayId: number): Promise<DayExercise[]> {
+  async findAll(
+    userId: number,
+    programId: number,
+    dayId: number,
+  ): Promise<DayExercise[]> {
     await this.ensureDayOwnership(userId, programId, dayId);
 
     return this.prisma.dayExercise.findMany({
-      where: {
-        programDayId: dayId,
-        programDay: { program: { userId } },
-      },
+      where: this.dayOwnershipWhere(userId, programId, dayId),
       orderBy: { order: 'asc' },
     });
   }
@@ -97,8 +120,7 @@ export class DayExercisesService {
     const de = await this.prisma.dayExercise.findFirst({
       where: {
         id: dayExerciseId,
-        programDayId: dayId,
-        programDay: { program: { userId } },
+        ...this.dayOwnershipWhere(userId, programId, dayId),
       },
     });
 
@@ -127,30 +149,107 @@ export class DayExercisesService {
       const res = await this.prisma.dayExercise.updateMany({
         where: {
           id: dayExerciseId,
-          programDayId: dayId,
-          programDay: { program: { userId } },
+          ...this.dayOwnershipWhere(userId, programId, dayId),
         },
         data,
       });
 
-      if (res.count === 0) throw new NotFoundException('Day exercise not found');
+      if (res.count === 0)
+        throw new NotFoundException('Day exercise not found');
 
       const updated = await this.prisma.dayExercise.findFirst({
         where: {
           id: dayExerciseId,
-          programDayId: dayId,
-          programDay: { program: { userId } },
+          ...this.dayOwnershipWhere(userId, programId, dayId),
         },
       });
 
       if (!updated) throw new NotFoundException('Day exercise not found');
       return updated;
     } catch (e) {
-      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
-        throw new ConflictException('Exercise order already exists for this day');
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'Exercise order already exists for this day',
+        );
       }
       throw e;
     }
+  }
+
+  async reorder(
+    userId: number,
+    programId: number,
+    dayId: number,
+    dto: ReorderDayExercisesDto,
+  ): Promise<DayExercise[]> {
+    await this.ensureDayOwnership(userId, programId, dayId);
+
+    const existingRows = await this.prisma.dayExercise.findMany({
+      where: this.dayOwnershipWhere(userId, programId, dayId),
+      select: { id: true },
+      orderBy: { order: 'asc' },
+    });
+
+    if (existingRows.length !== dto.items.length) {
+      throw new BadRequestException(
+        'Reorder payload must include all day exercises exactly once',
+      );
+    }
+
+    const existingIds = new Set(existingRows.map((row) => row.id));
+    const uniqueItemIds = new Set(dto.items.map((item) => item.id));
+    if (uniqueItemIds.size !== dto.items.length) {
+      throw new BadRequestException('Day exercise ids must be unique');
+    }
+    for (const id of uniqueItemIds) {
+      if (!existingIds.has(id)) {
+        throw new BadRequestException(
+          'Reorder payload contains ids outside the day',
+        );
+      }
+    }
+
+    const uniqueOrders = new Set(dto.items.map((item) => item.order));
+    if (uniqueOrders.size !== dto.items.length) {
+      throw new BadRequestException('Day exercise orders must be unique');
+    }
+    const sortedOrders = [...uniqueOrders].sort((a, b) => a - b);
+    for (let index = 0; index < sortedOrders.length; index += 1) {
+      if (sortedOrders[index] !== index + 1) {
+        throw new BadRequestException(
+          'Day exercise orders must be contiguous and start at 1',
+        );
+      }
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      const tempOffset = dto.items.length + 1000;
+
+      for (const item of dto.items) {
+        await tx.dayExercise.updateMany({
+          where: {
+            id: item.id,
+            ...this.dayOwnershipWhere(userId, programId, dayId),
+          },
+          data: { order: item.order + tempOffset },
+        });
+      }
+
+      for (const item of dto.items) {
+        await tx.dayExercise.updateMany({
+          where: {
+            id: item.id,
+            ...this.dayOwnershipWhere(userId, programId, dayId),
+          },
+          data: { order: item.order },
+        });
+      }
+    });
+
+    return this.findAll(userId, programId, dayId);
   }
 
   async remove(
@@ -160,15 +259,29 @@ export class DayExercisesService {
     dayExerciseId: number,
   ): Promise<void> {
     await this.ensureDayOwnership(userId, programId, dayId);
+    await this.prisma.$transaction(async (tx) => {
+      const res = await tx.dayExercise.deleteMany({
+        where: {
+          id: dayExerciseId,
+          ...this.dayOwnershipWhere(userId, programId, dayId),
+        },
+      });
 
-    const res = await this.prisma.dayExercise.deleteMany({
-      where: {
-        id: dayExerciseId,
-        programDayId: dayId,
-        programDay: { program: { userId } },
-      },
+      if (res.count === 0)
+        throw new NotFoundException('Day exercise not found');
+
+      const remainingRows = await tx.dayExercise.findMany({
+        where: this.dayOwnershipWhere(userId, programId, dayId),
+        select: { id: true },
+        orderBy: [{ order: 'asc' }, { id: 'asc' }],
+      });
+
+      for (let index = 0; index < remainingRows.length; index += 1) {
+        await tx.dayExercise.update({
+          where: { id: remainingRows[index].id },
+          data: { order: index + 1 },
+        });
+      }
     });
-
-    if (res.count === 0) throw new NotFoundException('Day exercise not found');
   }
 }

--- a/apps/api/src/modules/day-exercises/dto/reorder-day-exercises.dto.ts
+++ b/apps/api/src/modules/day-exercises/dto/reorder-day-exercises.dto.ts
@@ -1,0 +1,18 @@
+import { Type } from 'class-transformer';
+import { ArrayMinSize, IsArray, IsInt, ValidateNested } from 'class-validator';
+
+class DayExerciseOrderItemDto {
+  @IsInt()
+  id!: number;
+
+  @IsInt()
+  order!: number;
+}
+
+export class ReorderDayExercisesDto {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => DayExerciseOrderItemDto)
+  items!: DayExerciseOrderItemDto[];
+}

--- a/apps/web/src/app/programs/page.tsx
+++ b/apps/web/src/app/programs/page.tsx
@@ -45,6 +45,35 @@ type ProgramDayEditor = {
   newDayName: string;
 };
 
+type Exercise = {
+  id: number;
+  name: string;
+  primaryMuscle: string;
+};
+
+type DayExercise = {
+  id: number;
+  programDayId: number;
+  exerciseId: number;
+  order: number;
+  targetSets: number;
+  minReps: number;
+  maxReps: number;
+};
+
+type DayExerciseDraft = {
+  targetSets: string;
+  minReps: string;
+  maxReps: string;
+};
+
+type NewDayExerciseDraft = {
+  exerciseId: string;
+  targetSets: string;
+  minReps: string;
+  maxReps: string;
+};
+
 const PROGRAM_TYPES: ProgramType[] = ['AB', 'PPL', 'FULL_BODY', 'CUSTOM'];
 
 function formatProgramType(type: ProgramType) {
@@ -75,8 +104,36 @@ export default function ProgramsPage() {
   const [editingProgramId, setEditingProgramId] = useState<number | null>(null);
   const [editor, setEditor] = useState<ProgramEditor | null>(null);
   const [dayEditor, setDayEditor] = useState<ProgramDayEditor | null>(null);
+  const [exerciseCatalog, setExerciseCatalog] = useState<Exercise[]>([]);
+  const [editingProgramDayId, setEditingProgramDayId] = useState<number | null>(null);
+  const [dayExercises, setDayExercises] = useState<DayExercise[]>([]);
+  const [dayExerciseDrafts, setDayExerciseDrafts] = useState<Record<number, DayExerciseDraft>>({});
+  const [newDayExerciseDraft, setNewDayExerciseDraft] = useState<NewDayExerciseDraft>({
+    exerciseId: '',
+    targetSets: '3',
+    minReps: '8',
+    maxReps: '12',
+  });
 
   const activeProgram = useMemo(() => programs.find((p) => p.isActive) ?? null, [programs]);
+  const editingProgram = useMemo(
+    () => (editingProgramId === null ? null : programs.find((p) => p.id === editingProgramId) ?? null),
+    [editingProgramId, programs],
+  );
+  const exerciseNameById = useMemo(
+    () => Object.fromEntries(exerciseCatalog.map((exercise) => [exercise.id, exercise.name])),
+    [exerciseCatalog],
+  );
+
+  function parsePositiveInt(value: string): number | null {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed <= 0) return null;
+    return parsed;
+  }
+
+  function validateRepRange(minReps: number, maxReps: number): boolean {
+    return minReps <= maxReps;
+  }
 
   async function loadData() {
     setError(null);
@@ -86,14 +143,16 @@ export default function ProgramsPage() {
       const token = getToken();
       if (!token) throw new Error('Please login first (go to /)');
 
-      const [activeRes, programsRes] = await Promise.all([
+      const [activeRes, programsRes, exercisesRes] = await Promise.all([
         apiFetch<{ session: ActiveSession }>('/workouts/sessions/active', { token }),
         apiFetch<ProgramApi[]>('/programs', { token }),
+        apiFetch<Exercise[]>('/exercises', { token }),
       ]);
 
       const nextPrograms = programsRes.map(normalizeProgram);
       setActiveSession(activeRes.session);
       setPrograms(nextPrograms);
+      setExerciseCatalog(exercisesRes);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to load programs page');
     } finally {
@@ -118,6 +177,30 @@ export default function ProgramsPage() {
       return null;
     });
   }, [activeProgram]);
+
+  useEffect(() => {
+    if (!editingProgram) {
+      setEditingProgramDayId(null);
+      return;
+    }
+
+    setEditingProgramDayId((prev) => {
+      if (prev !== null && editingProgram.days.some((day) => day.id === prev)) {
+        return prev;
+      }
+      return editingProgram.days[0]?.id ?? null;
+    });
+  }, [editingProgram]);
+
+  useEffect(() => {
+    if (!editingProgram || editingProgramDayId === null) {
+      setDayExercises([]);
+      setDayExerciseDrafts({});
+      return;
+    }
+
+    loadDayExercises(editingProgram.id, editingProgramDayId);
+  }, [editingProgram, editingProgramDayId]);
 
   async function onStartWorkout() {
     if (selectedProgramDayId === null) {
@@ -211,6 +294,15 @@ export default function ProgramsPage() {
     setEditingProgramId(null);
     setEditor(null);
     setDayEditor(null);
+    setEditingProgramDayId(null);
+    setDayExercises([]);
+    setDayExerciseDrafts({});
+    setNewDayExerciseDraft({
+      exerciseId: '',
+      targetSets: '3',
+      minReps: '8',
+      maxReps: '12',
+    });
   }
 
   function setProgramDays(programId: number, days: ProgramDay[]) {
@@ -223,6 +315,34 @@ export default function ProgramsPage() {
         draftNameByDayId: Object.fromEntries(normalizedDays.map((day) => [day.id, day.name])),
       };
     });
+  }
+
+  async function loadDayExercises(programId: number, dayId: number) {
+    setError(null);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const rows = await apiFetch<DayExercise[]>(`/programs/${programId}/days/${dayId}/exercises`, { token });
+      const sorted = rows.slice().sort((a, b) => a.order - b.order);
+      setDayExercises(sorted);
+      setDayExerciseDrafts(
+        Object.fromEntries(
+          sorted.map((row) => [
+            row.id,
+            {
+              targetSets: String(row.targetSets),
+              minReps: String(row.minReps),
+              maxReps: String(row.maxReps),
+            },
+          ]),
+        ),
+      );
+    } catch (e: unknown) {
+      setDayExercises([]);
+      setDayExerciseDrafts({});
+      setError(e instanceof Error ? e.message : 'Failed to load day exercises');
+    }
   }
 
   async function createProgramDay(programId: number) {
@@ -347,6 +467,188 @@ export default function ProgramsPage() {
       setProgramDays(programId, nextDays);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to reorder program days');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function createDayExercise(programId: number) {
+    if (editingProgramDayId === null) {
+      setError('Choose a program day first');
+      return;
+    }
+
+    const exerciseId = parsePositiveInt(newDayExerciseDraft.exerciseId);
+    const targetSets = parsePositiveInt(newDayExerciseDraft.targetSets);
+    const minReps = parsePositiveInt(newDayExerciseDraft.minReps);
+    const maxReps = parsePositiveInt(newDayExerciseDraft.maxReps);
+
+    if (!exerciseId || !targetSets || !minReps || !maxReps) {
+      setError('Exercise and target fields must be positive numbers');
+      return;
+    }
+
+    if (!validateRepRange(minReps, maxReps)) {
+      setError('Min reps must be less than or equal to max reps');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      await apiFetch<DayExercise>(`/programs/${programId}/days/${editingProgramDayId}/exercises`, {
+        method: 'POST',
+        token,
+        body: JSON.stringify({
+          exerciseId,
+          order: dayExercises.length + 1,
+          targetSets,
+          minReps,
+          maxReps,
+        }),
+      });
+
+      setNewDayExerciseDraft((prev) => ({ ...prev, exerciseId: '' }));
+      await loadDayExercises(programId, editingProgramDayId);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to add day exercise');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveDayExercise(programId: number, dayExerciseId: number) {
+    if (editingProgramDayId === null) return;
+    const draft = dayExerciseDrafts[dayExerciseId];
+    if (!draft) return;
+
+    const targetSets = parsePositiveInt(draft.targetSets);
+    const minReps = parsePositiveInt(draft.minReps);
+    const maxReps = parsePositiveInt(draft.maxReps);
+    if (!targetSets || !minReps || !maxReps) {
+      setError('Target fields must be positive numbers');
+      return;
+    }
+    if (!validateRepRange(minReps, maxReps)) {
+      setError('Min reps must be less than or equal to max reps');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const updated = await apiFetch<DayExercise>(
+        `/programs/${programId}/days/${editingProgramDayId}/exercises/${dayExerciseId}`,
+        {
+          method: 'PATCH',
+          token,
+          body: JSON.stringify({ targetSets, minReps, maxReps }),
+        },
+      );
+
+      setDayExercises((prev) =>
+        prev
+          .map((row) =>
+            row.id === dayExerciseId
+              ? {
+                  ...row,
+                  targetSets: updated.targetSets,
+                  minReps: updated.minReps,
+                  maxReps: updated.maxReps,
+                }
+              : row,
+          )
+          .sort((a, b) => a.order - b.order),
+      );
+      setDayExerciseDrafts((prev) => ({
+        ...prev,
+        [dayExerciseId]: {
+          targetSets: String(updated.targetSets),
+          minReps: String(updated.minReps),
+          maxReps: String(updated.maxReps),
+        },
+      }));
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to save day exercise');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteDayExercise(programId: number, dayExerciseId: number) {
+    if (editingProgramDayId === null) return;
+
+    setError(null);
+    setSaving(true);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      await apiFetch<{ ok: true }>(
+        `/programs/${programId}/days/${editingProgramDayId}/exercises/${dayExerciseId}`,
+        {
+          method: 'DELETE',
+          token,
+        },
+      );
+
+      await loadDayExercises(programId, editingProgramDayId);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to delete day exercise');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function moveDayExercise(programId: number, dayExerciseId: number, direction: -1 | 1) {
+    if (editingProgramDayId === null) return;
+    const currentIndex = dayExercises.findIndex((row) => row.id === dayExerciseId);
+    if (currentIndex === -1) return;
+
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= dayExercises.length) return;
+
+    const reordered = [...dayExercises];
+    const [moved] = reordered.splice(currentIndex, 1);
+    reordered.splice(nextIndex, 0, moved);
+    const items = reordered.map((row, index) => ({ id: row.id, order: index + 1 }));
+
+    setError(null);
+    setSaving(true);
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const nextRows = await apiFetch<DayExercise[]>(
+        `/programs/${programId}/days/${editingProgramDayId}/exercises/reorder`,
+        {
+          method: 'POST',
+          token,
+          body: JSON.stringify({ items }),
+        },
+      );
+
+      setDayExercises(nextRows.slice().sort((a, b) => a.order - b.order));
+      setDayExerciseDrafts((prev) => {
+        const nextDrafts: Record<number, DayExerciseDraft> = {};
+        for (const row of nextRows) {
+          nextDrafts[row.id] =
+            prev[row.id] ?? {
+              targetSets: String(row.targetSets),
+              minReps: String(row.minReps),
+              maxReps: String(row.maxReps),
+            };
+        }
+        return nextDrafts;
+      });
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to reorder day exercises');
     } finally {
       setSaving(false);
     }
@@ -767,6 +1069,220 @@ export default function ProgramsPage() {
                                     </div>
                                   ))}
                               </div>
+                            )}
+                          </div>
+
+                          <div className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+                            <h4 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">
+                              DayExercises
+                            </h4>
+
+                            {program.days.length === 0 ? (
+                              <p className="text-sm text-zinc-400">
+                                Add at least one ProgramDay before configuring exercises.
+                              </p>
+                            ) : (
+                              <>
+                                <label className="flex flex-col gap-1">
+                                  <span className="text-sm text-zinc-400">Edit ProgramDay</span>
+                                  <select
+                                    className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                    value={editingProgramDayId ?? ''}
+                                    onChange={(e) => setEditingProgramDayId(Number(e.target.value))}
+                                    disabled={saving}
+                                  >
+                                    {program.days
+                                      .slice()
+                                      .sort((a, b) => a.order - b.order)
+                                      .map((day) => (
+                                        <option key={day.id} value={day.id}>
+                                          #{day.order} - {day.name}
+                                        </option>
+                                      ))}
+                                  </select>
+                                </label>
+
+                                <div className="grid gap-2 md:grid-cols-[1.2fr,repeat(3,minmax(0,120px)),auto]">
+                                  <label className="flex flex-col gap-1">
+                                    <span className="text-sm text-zinc-400">Exercise</span>
+                                    <select
+                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      value={newDayExerciseDraft.exerciseId}
+                                      onChange={(e) =>
+                                        setNewDayExerciseDraft((prev) => ({
+                                          ...prev,
+                                          exerciseId: e.target.value,
+                                        }))
+                                      }
+                                      disabled={saving}
+                                    >
+                                      <option value="">Select exercise</option>
+                                      {exerciseCatalog.map((exercise) => (
+                                        <option key={exercise.id} value={exercise.id}>
+                                          {exercise.name}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  </label>
+
+                                  <label className="flex flex-col gap-1">
+                                    <span className="text-sm text-zinc-400">Sets</span>
+                                    <input
+                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      inputMode="numeric"
+                                      value={newDayExerciseDraft.targetSets}
+                                      onChange={(e) =>
+                                        setNewDayExerciseDraft((prev) => ({
+                                          ...prev,
+                                          targetSets: e.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </label>
+
+                                  <label className="flex flex-col gap-1">
+                                    <span className="text-sm text-zinc-400">Min reps</span>
+                                    <input
+                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      inputMode="numeric"
+                                      value={newDayExerciseDraft.minReps}
+                                      onChange={(e) =>
+                                        setNewDayExerciseDraft((prev) => ({
+                                          ...prev,
+                                          minReps: e.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </label>
+
+                                  <label className="flex flex-col gap-1">
+                                    <span className="text-sm text-zinc-400">Max reps</span>
+                                    <input
+                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      inputMode="numeric"
+                                      value={newDayExerciseDraft.maxReps}
+                                      onChange={(e) =>
+                                        setNewDayExerciseDraft((prev) => ({
+                                          ...prev,
+                                          maxReps: e.target.value,
+                                        }))
+                                      }
+                                    />
+                                  </label>
+
+                                  <div className="flex items-end">
+                                    <button
+                                      className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm hover:bg-zinc-700 disabled:opacity-50"
+                                      onClick={() => createDayExercise(program.id)}
+                                      disabled={saving || editingProgramDayId === null}
+                                    >
+                                      Add
+                                    </button>
+                                  </div>
+                                </div>
+
+                                {dayExercises.length === 0 ? (
+                                  <p className="text-sm text-zinc-400">No exercises configured for this day.</p>
+                                ) : (
+                                  <div className="space-y-2">
+                                    {dayExercises.map((row, index) => (
+                                      <div
+                                        key={row.id}
+                                        className="grid gap-2 rounded-md border border-zinc-700 bg-zinc-900 p-3 md:grid-cols-[70px,1fr,repeat(3,minmax(0,110px)),auto]"
+                                      >
+                                        <div className="text-sm text-zinc-400">#{row.order}</div>
+                                        <div className="text-sm text-zinc-200">
+                                          {exerciseNameById[row.exerciseId] ?? `Exercise #${row.exerciseId}`}
+                                        </div>
+                                        <input
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                          inputMode="numeric"
+                                          value={dayExerciseDrafts[row.id]?.targetSets ?? String(row.targetSets)}
+                                          onChange={(e) =>
+                                            setDayExerciseDrafts((prev) => ({
+                                              ...prev,
+                                              [row.id]: {
+                                                ...(prev[row.id] ?? {
+                                                  targetSets: String(row.targetSets),
+                                                  minReps: String(row.minReps),
+                                                  maxReps: String(row.maxReps),
+                                                }),
+                                                targetSets: e.target.value,
+                                              },
+                                            }))
+                                          }
+                                        />
+                                        <input
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                          inputMode="numeric"
+                                          value={dayExerciseDrafts[row.id]?.minReps ?? String(row.minReps)}
+                                          onChange={(e) =>
+                                            setDayExerciseDrafts((prev) => ({
+                                              ...prev,
+                                              [row.id]: {
+                                                ...(prev[row.id] ?? {
+                                                  targetSets: String(row.targetSets),
+                                                  minReps: String(row.minReps),
+                                                  maxReps: String(row.maxReps),
+                                                }),
+                                                minReps: e.target.value,
+                                              },
+                                            }))
+                                          }
+                                        />
+                                        <input
+                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                          inputMode="numeric"
+                                          value={dayExerciseDrafts[row.id]?.maxReps ?? String(row.maxReps)}
+                                          onChange={(e) =>
+                                            setDayExerciseDrafts((prev) => ({
+                                              ...prev,
+                                              [row.id]: {
+                                                ...(prev[row.id] ?? {
+                                                  targetSets: String(row.targetSets),
+                                                  minReps: String(row.minReps),
+                                                  maxReps: String(row.maxReps),
+                                                }),
+                                                maxReps: e.target.value,
+                                              },
+                                            }))
+                                          }
+                                        />
+                                        <div className="flex flex-wrap gap-2">
+                                          <button
+                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                            onClick={() => moveDayExercise(program.id, row.id, -1)}
+                                            disabled={saving || index === 0}
+                                          >
+                                            Up
+                                          </button>
+                                          <button
+                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                            onClick={() => moveDayExercise(program.id, row.id, 1)}
+                                            disabled={saving || index === dayExercises.length - 1}
+                                          >
+                                            Down
+                                          </button>
+                                          <button
+                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                            onClick={() => saveDayExercise(program.id, row.id)}
+                                            disabled={saving}
+                                          >
+                                            Save
+                                          </button>
+                                          <button
+                                            className="rounded-md border border-red-500/50 bg-red-500/10 px-2 py-1 text-xs text-red-200 hover:bg-red-500/20 disabled:opacity-50"
+                                            onClick={() => deleteDayExercise(program.id, row.id)}
+                                            disabled={saving}
+                                          >
+                                            Delete
+                                          </button>
+                                        </div>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                              </>
                             )}
                           </div>
                         </div>


### PR DESCRIPTION
## What
- Added DayExercises editing capabilities to Programs editor UI:
  - select ProgramDay to configure
  - add DayExercise from exercise catalog
  - edit target fields (`targetSets`, `minReps`, `maxReps`)
  - reorder DayExercises (up/down)
  - delete DayExercises
- Added API endpoint:
  - `POST /programs/:programId/days/:dayId/exercises/reorder`
- Added DTO validation for reorder payload:
  - `ReorderDayExercisesDto`
- Hardened DayExercises service behavior:
  - reorder payload must include all day exercises exactly once
  - order values must be unique, contiguous, and start at 1
  - transactional two-phase reorder to avoid unique-order collisions
  - delete now re-normalizes remaining `order` values to contiguous sequence

## Why
- Completes Programs UX Overhaul Part 2 by enabling full DayExercise configuration in editor flow.
- Prevents fragile reorder behavior and keeps order invariants reliable.

## Scope
- `apps/web/src/app/programs/page.tsx`
- `apps/api/src/modules/day-exercises/day-exercises.controller.ts`
- `apps/api/src/modules/day-exercises/day-exercises.service.ts`
- `apps/api/src/modules/day-exercises/dto/reorder-day-exercises.dto.ts`

## Out of scope
- Program versioning
- Progress engine/dashboard changes
- User-created exercise catalog

## Implementation details
- Web fetches exercise catalog and day-exercise rows with typed contracts.
- Client-side guards enforce positive numeric targets and valid rep range (`minReps <= maxReps`) before submit.
- Reorder implementation uses temporary offset updates inside a transaction, then writes final order.
- Delete operation reassigns remaining orders (`1..n`) to preserve deterministic ordering.

## How to test
1. Open `/programs` and edit a program.
2. In DayExercises section:
   - pick a ProgramDay
   - add exercises with valid targets
   - modify and save targets
   - reorder with Up/Down
   - delete an exercise
3. Refresh page and verify order and targets persist.
4. Confirm ProgramDay start-workout flow still works.
5. Build checks:
   - `npm run build` in `apps/api`
   - `npm run build` in `apps/web`

## Closes
Closes #62
