### PR TITLE
Build premium dark UI foundation and align Progress/Session UX

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,26 +1,25 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --ui-bg: #07070a;
+  --ui-card: #15151d;
+  --ui-card-2: #1b1b25;
+  --ui-border: #323242;
+  --ui-accent: #2dd4bf;
+  --ui-accent-hover: #14b8a6;
+  --ui-text-primary: #fafafa;
+  --ui-text-secondary: #a1a1aa;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: var(--ui-bg);
+  --color-foreground: var(--ui-text-primary);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: radial-gradient(circle at top, #15151d 0%, #07070a 58%);
+  color: var(--ui-text-primary);
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -2,144 +2,113 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { apiFetch } from '@/lib/api';
-import { clearToken, getToken } from '@/lib/auth';
 import { useRouter } from 'next/navigation';
 import { AppShell } from '@/components/app-shell';
+import { Badge } from '@/components/ui/badge';
+import { SecondaryButton, buttonClass } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeader } from '@/components/ui/section-header';
+import { apiFetch } from '@/lib/api';
+import { clearToken, getToken } from '@/lib/auth';
 
 type ActiveSession = {
-    id: number;
-    startedAt: string;
-    endedAt: string | null;
-    programId: number;
-    programDayId: number;
+  id: number;
+  startedAt: string;
+  endedAt: string | null;
+  programId: number;
+  programDayId: number;
 };
 
 type LastSession = {
-    id: number;
-    startedAt: string;
-    endedAt: string;
-    program: { id: number; name: string; type: string };
-    programDay: { id: number; name: string; order: number };
+  id: number;
+  startedAt: string;
+  endedAt: string;
+  program: { id: number; name: string; type: string };
+  programDay: { id: number; name: string; order: number };
 };
 
 export default function HomePage() {
-    const [active, setActive] = useState<ActiveSession | null>(null);
-    const [last, setLast] = useState<LastSession | null>(null);
-    const [error, setError] = useState<string | null>(null);
+  const [active, setActive] = useState<ActiveSession | null>(null);
+  const [last, setLast] = useState<LastSession | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-    const router = useRouter();
+  const router = useRouter();
 
-    function logout() {
-        clearToken();
-        router.replace('/');
+  function logout() {
+    clearToken();
+    router.replace('/');
+  }
+
+  async function load() {
+    setError(null);
+
+    try {
+      const token = getToken();
+      if (!token) throw new Error('Please login first (go to /)');
+
+      const activeRes = await apiFetch<{ session: ActiveSession | null }>('/workouts/sessions/active', { token });
+      const lastRes = await apiFetch<{ session: LastSession | null }>('/workouts/sessions/last', { token });
+
+      setActive(activeRes.session);
+      setLast(lastRes.session);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load home data');
     }
+  }
 
-    async function load() {
-        setError(null);
+  useEffect(() => {
+    load();
+  }, []);
 
-        try {
-            const token = getToken();
-            if (!token) throw new Error('Please login first (go to /)');
+  return (
+    <AppShell title="Home" actions={<SecondaryButton onClick={logout}>Logout</SecondaryButton>}>
+      {error && <p className="text-sm text-red-400">{error}</p>}
 
-            const activeRes = await apiFetch<{ session: ActiveSession | null }>(
-                '/workouts/sessions/active',
-                { token }
-            );
+      <Card padding="lg" className="space-y-3">
+        <SectionHeader title="Workout status" />
 
-            const lastRes = await apiFetch<{ session: LastSession | null }>(
-                '/workouts/sessions/last',
-                { token }
-            );
-
-            setActive(activeRes.session);
-            setLast(lastRes.session);
-        } catch (e: unknown) {
-            setError(e instanceof Error ? e.message : 'Failed to load home data');
-        }
-    }
-
-    useEffect(() => {
-        load();
-    }, []);
-
-    return (
-        <AppShell
-            title="Home"
-            actions={
-                <button
-                    className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-                    onClick={logout}
-                >
-                    Logout
-                </button>
-            }
-        >
-            {error && <p className="text-red-400 text-sm">{error}</p>}
-
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
-                <div className="font-semibold text-lg">Workout status</div>
-
-                {active ? (
-                    <>
-                        <div className="text-zinc-300 text-sm">
-                            You have an active workout started at{' '}
-                            {new Date(active.startedAt).toLocaleString()}
-                        </div>
-
-                        <Link
-                            href={`/workouts/sessions/${active.id}`}
-                            className="inline-block rounded-md bg-green-500 text-black px-4 py-2 font-semibold"
-                        >
-                            Resume workout
-                        </Link>
-                    </>
-                ) : (
-                    <>
-                        <div className="text-zinc-300 text-sm">
-                            No active workout session.
-                        </div>
-
-                        <Link
-                            href="/programs"
-                            className="inline-block rounded-md bg-white text-black px-4 py-2 font-semibold"
-                        >
-                            Start workout
-                        </Link>
-                    </>
-                )}
+        {active ? (
+          <>
+            <div className="text-sm text-[var(--ui-text-secondary)]">
+              You have an active workout started at {new Date(active.startedAt).toLocaleString()}
             </div>
 
-            <div className="rounded-md bg-zinc-800 border border-zinc-700 p-5 space-y-3">
-                <div className="font-semibold text-lg">Last workout</div>
+            <Link href={`/workouts/sessions/${active.id}`} className={buttonClass('primary')}>
+              Resume workout
+            </Link>
+          </>
+        ) : (
+          <>
+            <div className="text-sm text-[var(--ui-text-secondary)]">No active workout session.</div>
 
-                {last ? (
-                    <>
-                        <div className="text-zinc-200">
-                            <span className="font-semibold">
-                                {last.program.name}
-                            </span>{' '}
-                            - {last.programDay.name}
-                        </div>
+            <Link href="/programs" className={buttonClass('primary')}>
+              Start workout
+            </Link>
+          </>
+        )}
+      </Card>
 
-                        <div className="text-sm text-zinc-400">
-                            Completed at {new Date(last.endedAt).toLocaleString()}
-                        </div>
+      <Card padding="lg" className="space-y-3">
+        <SectionHeader title="Last workout" action={last ? <Badge variant="active">Completed</Badge> : null} />
 
-                        <Link
-                            href={`/workouts/sessions/${last.id}/summary`}
-                            className="inline-block rounded-md bg-zinc-700 px-4 py-2"
-                        >
-                            View summary
-                        </Link>
-                    </>
-                ) : (
-                    <div className="text-zinc-400 text-sm">
-                        No workouts completed yet.
-                    </div>
-                )}
+        {last ? (
+          <>
+            <div className="text-[var(--ui-text-primary)]">
+              <span className="font-semibold">{last.program.name}</span> - {last.programDay.name}
             </div>
-        </AppShell>
-    );
+
+            <div className="text-sm text-[var(--ui-text-secondary)]">
+              Completed at {new Date(last.endedAt).toLocaleString()}
+            </div>
+
+            <Link href={`/workouts/sessions/${last.id}/summary`} className={buttonClass('secondary')}>
+              View summary
+            </Link>
+          </>
+        ) : (
+          <div className="text-sm text-[var(--ui-text-secondary)]">No workouts completed yet.</div>
+        )}
+      </Card>
+    </AppShell>
+  );
 }
-

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,10 +2,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Card } from '@/components/ui/card';
+import { PrimaryButton, SecondaryButton } from '@/components/ui/button';
+import { SectionHeader } from '@/components/ui/section-header';
 import { apiFetch } from '@/lib/api';
 import { clearToken, getToken, setToken } from '@/lib/auth';
-import { useRouter } from 'next/navigation';
-
 
 type Program = { id: number; name: string; type: string; isActive?: boolean };
 
@@ -18,13 +20,11 @@ export default function HomePage() {
 
   const router = useRouter();
 
-
   useEffect(() => {
     const t = getToken();
     setTok(t);
     if (t) router.replace('/home');
   }, []);
-
 
   async function devLogin() {
     setError(null);
@@ -38,7 +38,6 @@ export default function HomePage() {
       setTok(res.accessToken);
 
       router.push('/home');
-
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Login failed');
     }
@@ -69,75 +68,59 @@ export default function HomePage() {
   }, [token]);
 
   return (
-    <main className="min-h-screen bg-zinc-900 text-zinc-100 px-6 py-10">
-      <div className="max-w-3xl mx-auto space-y-8">
-        <h1 className="text-5xl font-extrabold tracking-tight">SETLYX — Dev UI</h1>
+    <main className="min-h-screen px-4 py-8 md:px-6">
+      <div className="mx-auto flex min-h-[calc(100vh-4rem)] max-w-5xl items-center justify-center">
+        <div className="w-full max-w-md space-y-6">
+          <h1 className="text-center text-4xl font-extrabold tracking-tight md:text-5xl">SETLYX</h1>
 
-        {!token ? (
-          <section className="space-y-4">
-            <h2 className="text-xl font-semibold">Dev Login</h2>
+          {!token ? (
+            <Card padding="lg" className="space-y-4">
+              <SectionHeader title="Dev Login" />
 
-            <div className="flex gap-3 items-center">
-              <input
-                className="w-40 rounded-md bg-zinc-800 border border-zinc-700 px-3 py-2 outline-none focus:ring-2 focus:ring-zinc-500"
-                value={userId}
-                onChange={(e) => setUserId(e.target.value)}
-                placeholder="userId"
+              <div className="flex items-center gap-3">
+                <input
+                  className="w-40 rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  value={userId}
+                  onChange={(e) => setUserId(e.target.value)}
+                  placeholder="userId"
+                />
+                <PrimaryButton onClick={devLogin}>Login</PrimaryButton>
+              </div>
+
+              {error && <p className="text-sm text-red-400">{error}</p>}
+            </Card>
+          ) : (
+            <Card padding="lg" className="space-y-4">
+              <div className="flex flex-wrap gap-3">
+                <SecondaryButton onClick={logout}>Logout</SecondaryButton>
+                <PrimaryButton onClick={() => router.push('/programs')}>Go to Start/Resume</PrimaryButton>
+              </div>
+
+              <SectionHeader
+                title="Programs"
+                action={
+                  <SecondaryButton onClick={loadPrograms} disabled={loadingPrograms}>
+                    {loadingPrograms ? 'Loading...' : 'Refresh'}
+                  </SecondaryButton>
+                }
               />
-              <button
-                className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white"
-                onClick={devLogin}
-              >
-                Login
-              </button>
-            </div>
 
-            {error && <p className="text-red-400 text-sm">{error}</p>}
-          </section>
-        ) : (
-          <section className="space-y-4">
-            <button
-              className="rounded-md bg-zinc-800 border border-zinc-700 px-4 py-2 hover:bg-zinc-700"
-              onClick={logout}
-            >
-              Logout
-            </button>
+              {error && <p className="text-sm text-red-400">{error}</p>}
 
-            <button
-              className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white"
-              onClick={() => router.push('/programs')}
-            >
-              Go to Start/Resume
-            </button>
-
-
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Programs</h2>
-              <button
-                className="rounded-md bg-zinc-100 text-zinc-900 px-4 py-2 font-semibold hover:bg-white disabled:opacity-50"
-                onClick={loadPrograms}
-                disabled={loadingPrograms}
-              >
-                {loadingPrograms ? 'Loading...' : 'Refresh'}
-              </button>
-            </div>
-
-            {error && <p className="text-red-400 text-sm">{error}</p>}
-
-            <ul className="space-y-2">
-              {programs.map((p) => (
-                <li key={p.id} className="rounded-md bg-zinc-800 border border-zinc-700 p-3">
-                  <span className="font-semibold">#{p.id}</span> — {p.name} ({p.type})
-                </li>
-              ))}
-              {programs.length === 0 && (
-                <li className="text-zinc-400 text-sm">No programs found.</li>
-              )}
-            </ul>
-          </section>
-        )}
+              <ul className="space-y-2">
+                {programs.map((p) => (
+                  <li key={p.id} className="rounded-md border border-[var(--ui-border)] bg-zinc-900 p-3">
+                    <span className="font-semibold">#{p.id}</span> - {p.name} ({p.type})
+                  </li>
+                ))}
+                {programs.length === 0 && (
+                  <li className="text-sm text-[var(--ui-text-secondary)]">No programs found.</li>
+                )}
+              </ul>
+            </Card>
+          )}
+        </div>
       </div>
     </main>
   );
 }
-

--- a/apps/web/src/app/programs/page.tsx
+++ b/apps/web/src/app/programs/page.tsx
@@ -5,6 +5,10 @@ import { useRouter } from 'next/navigation';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
 import { AppShell } from '@/components/app-shell';
+import { Badge } from '@/components/ui/badge';
+import { DangerButton, PrimaryButton, SecondaryButton } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeader } from '@/components/ui/section-header';
 
 type ActiveSession = {
   id: number;
@@ -816,13 +820,9 @@ export default function ProgramsPage() {
     <AppShell
       title="Programs"
       actions={
-        <button
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
-          onClick={loadData}
-          disabled={loading || saving}
-        >
+        <SecondaryButton onClick={loadData} disabled={loading || saving}>
           Refresh
-        </button>
+        </SecondaryButton>
       }
     >
       {error && <p className="text-sm text-red-400">{error}</p>}
@@ -831,38 +831,33 @@ export default function ProgramsPage() {
         <p>Loading...</p>
       ) : (
         <>
-          <section className="space-y-3 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Workout entrypoint</h2>
-              {activeProgram ? (
-                <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-300">
-                  Active program: {activeProgram.name}
-                </span>
-              ) : (
-                <span className="rounded-full border border-zinc-600 px-3 py-1 text-xs text-zinc-300">
-                  No active program
-                </span>
-              )}
-            </div>
+          <Card padding="lg" className="space-y-3">
+            <SectionHeader
+              title="Workout entrypoint"
+              action={
+                activeProgram ? (
+                  <Badge variant="active">Active program: {activeProgram.name}</Badge>
+                ) : (
+                  <Badge>No active program</Badge>
+                )
+              }
+            />
 
             {activeSession ? (
               <div className="flex flex-wrap items-center gap-3">
                 <div className="text-sm text-zinc-300">
                   Active session #{activeSession.id} started at {new Date(activeSession.startedAt).toLocaleString()}
                 </div>
-                <button
-                  className="rounded-md bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-900 hover:bg-white"
-                  onClick={onResumeWorkout}
-                >
+                <PrimaryButton onClick={onResumeWorkout}>
                   Resume workout
-                </button>
+                </PrimaryButton>
               </div>
             ) : (
               <div className="grid gap-3 md:grid-cols-3">
                 <label className="flex flex-col gap-1 md:col-span-2">
                   <span className="text-sm text-zinc-400">Program day</span>
                   <select
-                    className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none disabled:opacity-60"
+                    className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none disabled:opacity-60"
                     value={selectedProgramDayId ?? ''}
                     onChange={(e) => setSelectedProgramDayId(Number(e.target.value))}
                     disabled={!activeProgram || activeProgram.days.length === 0}
@@ -879,13 +874,13 @@ export default function ProgramsPage() {
                 </label>
 
                 <div className="flex items-end">
-                  <button
-                    className="w-full rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
+                  <PrimaryButton
+                    className="w-full"
                     onClick={onStartWorkout}
                     disabled={saving || selectedProgramDayId === null}
                   >
                     Start workout
-                  </button>
+                  </PrimaryButton>
                 </div>
 
                 {!activeProgram && (
@@ -900,16 +895,16 @@ export default function ProgramsPage() {
                 )}
               </div>
             )}
-          </section>
+          </Card>
 
-          <section className="space-y-4 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
-            <h2 className="text-xl font-semibold">Create program</h2>
+          <Card padding="lg" className="space-y-4">
+            <SectionHeader title="Create program" />
 
             <div className="grid gap-3 md:grid-cols-3">
               <label className="flex flex-col gap-1 md:col-span-2">
                 <span className="text-sm text-zinc-400">Name</span>
                 <input
-                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                  className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                   value={createName}
                   onChange={(e) => setCreateName(e.target.value)}
                   placeholder="e.g. Hypertrophy Block"
@@ -919,7 +914,7 @@ export default function ProgramsPage() {
               <label className="flex flex-col gap-1">
                 <span className="text-sm text-zinc-400">Type</span>
                 <select
-                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                  className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                   value={createType}
                   onChange={(e) => setCreateType(e.target.value as ProgramType)}
                 >
@@ -942,17 +937,13 @@ export default function ProgramsPage() {
               Set as active program
             </label>
 
-            <button
-              className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
-              onClick={onCreateProgram}
-              disabled={saving}
-            >
+            <PrimaryButton onClick={onCreateProgram} disabled={saving}>
               Create program
-            </button>
-          </section>
+            </PrimaryButton>
+          </Card>
 
-          <section className="space-y-4 rounded-lg border border-zinc-700 bg-zinc-800 p-5">
-            <h2 className="text-xl font-semibold">Your programs</h2>
+          <Card padding="lg" className="space-y-4">
+            <SectionHeader title="Your programs" />
 
             {programs.length === 0 ? (
               <p className="text-sm text-zinc-400">No programs yet. Create your first program above.</p>
@@ -962,15 +953,13 @@ export default function ProgramsPage() {
                   const isEditing = editingProgramId === program.id && editor !== null;
 
                   return (
-                    <article key={program.id} className="rounded-md border border-zinc-700 bg-zinc-900 p-4">
+                    <article key={program.id} className="rounded-md border border-[var(--ui-border)] bg-zinc-900 p-4">
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
                           <div className="flex items-center gap-2">
                             <h3 className="text-lg font-semibold">{isEditing ? editor.name : program.name}</h3>
                             {program.isActive && (
-                              <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-300">
-                                Active
-                              </span>
+                              <Badge variant="active">Active</Badge>
                             )}
                           </div>
                           <p className="text-sm text-zinc-400">
@@ -983,38 +972,22 @@ export default function ProgramsPage() {
 
                         {isEditing ? (
                           <div className="flex gap-2">
-                            <button
-                              className="rounded-md bg-zinc-100 px-3 py-2 text-sm font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
-                              onClick={() => saveEdit(program.id)}
-                              disabled={saving}
-                            >
+                            <PrimaryButton onClick={() => saveEdit(program.id)} disabled={saving}>
                               Save
-                            </button>
-                            <button
-                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm hover:bg-zinc-700"
-                              onClick={cancelEdit}
-                              disabled={saving}
-                            >
+                            </PrimaryButton>
+                            <SecondaryButton onClick={cancelEdit} disabled={saving}>
                               Cancel
-                            </button>
+                            </SecondaryButton>
                           </div>
                         ) : (
                           <div className="flex gap-2">
-                            <button
-                              className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm hover:bg-zinc-700"
-                              onClick={() => beginEdit(program)}
-                              disabled={saving}
-                            >
+                            <SecondaryButton onClick={() => beginEdit(program)} disabled={saving}>
                               Edit
-                            </button>
+                            </SecondaryButton>
                             {!program.isActive && (
-                              <button
-                                className="rounded-md border border-emerald-500/50 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 hover:bg-emerald-500/20"
-                                onClick={() => setProgramActive(program.id)}
-                                disabled={saving}
-                              >
+                              <PrimaryButton onClick={() => setProgramActive(program.id)} disabled={saving}>
                                 Set active
-                              </button>
+                              </PrimaryButton>
                             )}
                           </div>
                         )}
@@ -1026,7 +999,7 @@ export default function ProgramsPage() {
                             <label className="flex flex-col gap-1 md:col-span-2">
                               <span className="text-sm text-zinc-400">Name</span>
                               <input
-                                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                                className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-3 py-2 outline-none"
                                 value={editor.name}
                                 onChange={(e) =>
                                   setEditor((prev) => (prev ? { ...prev, name: e.target.value } : prev))
@@ -1037,7 +1010,7 @@ export default function ProgramsPage() {
                             <label className="flex flex-col gap-1">
                               <span className="text-sm text-zinc-400">Type</span>
                               <select
-                                className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 outline-none"
+                                className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-3 py-2 outline-none"
                                 value={editor.type}
                                 onChange={(e) =>
                                   setEditor((prev) =>
@@ -1068,7 +1041,7 @@ export default function ProgramsPage() {
                             </label>
                           </div>
 
-                          <div className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+                          <div className="space-y-3 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-4">
                             <h4 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">
                               ProgramDays
                             </h4>
@@ -1077,7 +1050,7 @@ export default function ProgramsPage() {
                               <label className="flex min-w-[220px] flex-1 flex-col gap-1">
                                 <span className="text-sm text-zinc-400">New day name</span>
                                 <input
-                                  className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                  className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                   value={dayEditor?.newDayName ?? ''}
                                   onChange={(e) =>
                                     setDayEditor((prev) =>
@@ -1087,30 +1060,26 @@ export default function ProgramsPage() {
                                   placeholder="e.g. Lower A"
                                 />
                               </label>
-                              <button
-                                className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm hover:bg-zinc-700 disabled:opacity-50"
-                                onClick={() => createProgramDay(program.id)}
-                                disabled={saving}
-                              >
+                              <SecondaryButton onClick={() => createProgramDay(program.id)} disabled={saving}>
                                 Add day
-                              </button>
+                              </SecondaryButton>
                             </div>
 
                             {program.days.length === 0 ? (
                               <p className="text-sm text-zinc-400">No days yet.</p>
                             ) : (
-                              <div className="space-y-2">
+                              <div className="space-y-2 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card)] p-2">
                                 {program.days
                                   .slice()
                                   .sort((a, b) => a.order - b.order)
                                   .map((day, index, arr) => (
                                     <div
                                       key={day.id}
-                                      className="grid gap-2 rounded-md border border-zinc-700 bg-zinc-900 p-3 md:grid-cols-[80px,1fr,auto]"
+                                      className="grid gap-2 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3 md:grid-cols-[80px,1fr,auto]"
                                     >
                                       <div className="text-sm text-zinc-400">#{day.order}</div>
                                       <input
-                                        className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm outline-none"
+                                        className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-3 py-2 text-sm outline-none"
                                         value={dayEditor?.draftNameByDayId[day.id] ?? day.name}
                                         onChange={(e) =>
                                           setDayEditor((prev) =>
@@ -1127,34 +1096,34 @@ export default function ProgramsPage() {
                                         }
                                       />
                                       <div className="flex flex-wrap gap-2">
-                                        <button
-                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                        <SecondaryButton
+                                          className="px-2 py-1 text-xs"
                                           onClick={() => moveProgramDay(program.id, day.id, -1)}
                                           disabled={saving || index === 0}
                                         >
                                           Up
-                                        </button>
-                                        <button
-                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                        </SecondaryButton>
+                                        <SecondaryButton
+                                          className="px-2 py-1 text-xs"
                                           onClick={() => moveProgramDay(program.id, day.id, 1)}
                                           disabled={saving || index === arr.length - 1}
                                         >
                                           Down
-                                        </button>
-                                        <button
-                                          className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                        </SecondaryButton>
+                                        <SecondaryButton
+                                          className="px-2 py-1 text-xs"
                                           onClick={() => renameProgramDay(program.id, day.id)}
                                           disabled={saving}
                                         >
                                           Rename
-                                        </button>
-                                        <button
-                                          className="rounded-md border border-red-500/50 bg-red-500/10 px-2 py-1 text-xs text-red-200 hover:bg-red-500/20 disabled:opacity-50"
+                                        </SecondaryButton>
+                                        <DangerButton
+                                          className="px-2 py-1 text-xs"
                                           onClick={() => deleteProgramDay(program.id, day.id)}
                                           disabled={saving}
                                         >
                                           Delete
-                                        </button>
+                                        </DangerButton>
                                       </div>
                                     </div>
                                   ))}
@@ -1162,7 +1131,7 @@ export default function ProgramsPage() {
                             )}
                           </div>
 
-                          <div className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4">
+                          <div className="space-y-3 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-4">
                             <h4 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">
                               DayExercises
                             </h4>
@@ -1176,7 +1145,7 @@ export default function ProgramsPage() {
                                 <label className="flex flex-col gap-1">
                                   <span className="text-sm text-zinc-400">Edit ProgramDay</span>
                                   <select
-                                    className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                    className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                     value={editingProgramDayId ?? ''}
                                     onChange={(e) => setEditingProgramDayId(Number(e.target.value))}
                                     disabled={saving}
@@ -1196,7 +1165,7 @@ export default function ProgramsPage() {
                                   <label className="flex flex-col gap-1">
                                     <span className="text-sm text-zinc-400">Exercise</span>
                                     <select
-                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                       value={newDayExerciseDraft.exerciseId}
                                       onChange={(e) =>
                                         setNewDayExerciseDraft((prev) => ({
@@ -1221,7 +1190,7 @@ export default function ProgramsPage() {
                                   <label className="flex flex-col gap-1">
                                     <span className="text-sm text-zinc-400">Sets</span>
                                     <input
-                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                       inputMode="numeric"
                                       value={newDayExerciseDraft.targetSets}
                                       onChange={(e) =>
@@ -1239,7 +1208,7 @@ export default function ProgramsPage() {
                                   <label className="flex flex-col gap-1">
                                     <span className="text-sm text-zinc-400">Min reps</span>
                                     <input
-                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                       inputMode="numeric"
                                       value={newDayExerciseDraft.minReps}
                                       onChange={(e) =>
@@ -1257,7 +1226,7 @@ export default function ProgramsPage() {
                                   <label className="flex flex-col gap-1">
                                     <span className="text-sm text-zinc-400">Max reps</span>
                                     <input
-                                      className="rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                                      className="rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 outline-none"
                                       inputMode="numeric"
                                       value={newDayExerciseDraft.maxReps}
                                       onChange={(e) =>
@@ -1273,13 +1242,13 @@ export default function ProgramsPage() {
                                   </label>
 
                                   <div className="flex items-end">
-                                    <button
-                                      className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm hover:bg-zinc-700 disabled:opacity-50"
+                                    <SecondaryButton
+                                      className="w-full"
                                       onClick={() => createDayExercise(program.id)}
                                       disabled={saving || editingProgramDayId === null}
                                     >
                                       Add
-                                    </button>
+                                    </SecondaryButton>
                                   </div>
                                 </div>
                                 {dayExerciseCreateError && (
@@ -1289,11 +1258,11 @@ export default function ProgramsPage() {
                                 {dayExercises.length === 0 ? (
                                   <p className="text-sm text-zinc-400">No exercises configured for this day.</p>
                                 ) : (
-                                  <div className="space-y-2">
+                                  <div className="space-y-2 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card)] p-2">
                                     {dayExercises.map((row, index) => (
                                       <div
                                         key={row.id}
-                                        className="space-y-3 rounded-md border border-zinc-700 bg-zinc-900 p-3"
+                                        className="space-y-3 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3"
                                       >
                                         <div className="text-sm text-zinc-400">#{row.order}</div>
                                         <div className="text-sm text-zinc-200">
@@ -1302,7 +1271,7 @@ export default function ProgramsPage() {
                                         <div className="grid gap-2 md:grid-cols-3">
                                           <input
                                             aria-label="Target sets"
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                            className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-2 py-1 text-sm outline-none"
                                             inputMode="numeric"
                                             value={dayExerciseDrafts[row.id]?.targetSets ?? String(row.targetSets)}
                                             onChange={(e) => {
@@ -1326,7 +1295,7 @@ export default function ProgramsPage() {
                                           />
                                           <input
                                             aria-label="Min reps"
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                            className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-2 py-1 text-sm outline-none"
                                             inputMode="numeric"
                                             value={dayExerciseDrafts[row.id]?.minReps ?? String(row.minReps)}
                                             onChange={(e) => {
@@ -1350,7 +1319,7 @@ export default function ProgramsPage() {
                                           />
                                           <input
                                             aria-label="Max reps"
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-sm outline-none"
+                                            className="rounded-md border border-[var(--ui-border)] bg-zinc-800 px-2 py-1 text-sm outline-none"
                                             inputMode="numeric"
                                             value={dayExerciseDrafts[row.id]?.maxReps ?? String(row.maxReps)}
                                             onChange={(e) => {
@@ -1374,34 +1343,34 @@ export default function ProgramsPage() {
                                           />
                                         </div>
                                         <div className="flex flex-wrap gap-2">
-                                          <button
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          <SecondaryButton
+                                            className="px-2 py-1 text-xs"
                                             onClick={() => moveDayExercise(program.id, row.id, -1)}
                                             disabled={saving || index === 0}
                                           >
                                             Up
-                                          </button>
-                                          <button
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          </SecondaryButton>
+                                          <SecondaryButton
+                                            className="px-2 py-1 text-xs"
                                             onClick={() => moveDayExercise(program.id, row.id, 1)}
                                             disabled={saving || index === dayExercises.length - 1}
                                           >
                                             Down
-                                          </button>
-                                          <button
-                                            className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs hover:bg-zinc-700 disabled:opacity-50"
+                                          </SecondaryButton>
+                                          <SecondaryButton
+                                            className="px-2 py-1 text-xs"
                                             onClick={() => saveDayExercise(program.id, row.id)}
                                             disabled={saving}
                                           >
                                             Save
-                                          </button>
-                                          <button
-                                            className="rounded-md border border-red-500/50 bg-red-500/10 px-2 py-1 text-xs text-red-200 hover:bg-red-500/20 disabled:opacity-50"
+                                          </SecondaryButton>
+                                          <DangerButton
+                                            className="px-2 py-1 text-xs"
                                             onClick={() => deleteDayExercise(program.id, row.id)}
                                             disabled={saving}
                                           >
                                             Delete
-                                          </button>
+                                          </DangerButton>
                                         </div>
                                         {dayExerciseSaveErrors[row.id] && (
                                           <p className="text-sm text-red-400">
@@ -1422,7 +1391,7 @@ export default function ProgramsPage() {
                 })}
               </div>
             )}
-          </section>
+          </Card>
         </>
       )}
     </AppShell>

--- a/apps/web/src/app/progress/page.tsx
+++ b/apps/web/src/app/progress/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { AppShell } from '@/components/app-shell';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { SegmentedControl } from '@/components/ui/segmented-control';
+import { SectionHeader } from '@/components/ui/section-header';
+import { StatCard } from '@/components/ui/stat-card';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
 
@@ -70,7 +75,7 @@ function toChartPoints(
   values: Array<number | null>,
   width: number,
   height: number,
-  padding: number,
+  yPadding: number,
 ): { points: ChartPoint[]; min: number; max: number } {
   const numeric = values.filter((v): v is number => v !== null);
   if (numeric.length === 0) return { points: [], min: 0, max: 0 };
@@ -78,13 +83,12 @@ function toChartPoints(
   const min = Math.min(...numeric);
   const max = Math.max(...numeric);
   const range = max - min || 1;
-  const innerWidth = width - padding * 2;
-  const innerHeight = height - padding * 2;
+  const innerHeight = height - yPadding * 2;
 
   const points = values.map((value, index) => {
     if (value === null) return null;
-    const x = padding + (values.length === 1 ? innerWidth / 2 : (index / (values.length - 1)) * innerWidth);
-    const y = padding + innerHeight - ((value - min) / range) * innerHeight;
+    const x = values.length === 1 ? width / 2 : (index / (values.length - 1)) * width;
+    const y = yPadding + innerHeight - ((value - min) / range) * innerHeight;
     return { x, y };
   }).filter((p): p is ChartPoint => p !== null);
 
@@ -93,6 +97,14 @@ function toChartPoints(
 
 function pointsToPolyline(points: ChartPoint[]): string {
   return points.map((p) => `${p.x},${p.y}`).join(' ');
+}
+
+function pointsToArea(points: ChartPoint[], baselineY: number): string {
+  if (points.length === 0) return '';
+  const topPath = pointsToPolyline(points);
+  const first = points[0];
+  const last = points[points.length - 1];
+  return `${topPath} ${last.x},${baselineY} ${first.x},${baselineY}`;
 }
 
 export default function ProgressPage() {
@@ -105,6 +117,7 @@ export default function ProgressPage() {
   const [selectedProgramDayId, setSelectedProgramDayId] = useState<number | null>(null);
   const [metric, setMetric] = useState<ProgressMetric>('e1rm');
   const [series, setSeries] = useState<ProgressSeriesResponse | null>(null);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
   const selectedProgram = useMemo(
     () => programs.find((program) => program.id === selectedProgramId) ?? null,
@@ -204,38 +217,67 @@ export default function ProgressPage() {
   const chart = useMemo(() => {
     const width = 860;
     const height = 320;
-    const padding = 26;
+    const yPadding = 14;
     const values = series?.points.map((p) => p.value ?? null) ?? [];
     const emaValues = series?.points.map((p) => p.emaValue ?? null) ?? [];
-    const raw = toChartPoints(values, width, height, padding);
-    const ema = toChartPoints(emaValues, width, height, padding);
+    const raw = toChartPoints(values, width, height, yPadding);
+    const ema = toChartPoints(emaValues, width, height, yPadding);
     const min = Math.min(raw.min, ema.min);
     const max = Math.max(raw.max, ema.max);
-    return { width, height, padding, raw, ema, min, max };
+    return { width, height, yPadding, raw, ema, min, max };
   }, [series]);
+
+  useEffect(() => {
+    setHoveredIndex(null);
+  }, [series, metric, selectedProgramDayId, selectedProgramId]);
+
+  const hoveredPoint = useMemo(() => {
+    if (!series || hoveredIndex === null || hoveredIndex < 0 || hoveredIndex >= series.points.length) return null;
+    const point = series.points[hoveredIndex];
+    const x = series.points.length === 1 ? chart.width / 2 : (hoveredIndex / (series.points.length - 1)) * chart.width;
+    return { point, x };
+  }, [series, hoveredIndex, chart.width]);
+
+  function onChartMouseMove(event: React.MouseEvent<SVGSVGElement>) {
+    if (!series || series.points.length === 0) return;
+    const svg = event.currentTarget;
+    const bounds = svg.getBoundingClientRect();
+    if (bounds.width <= 0) return;
+    const ratio = (event.clientX - bounds.left) / bounds.width;
+    const x = Math.max(0, Math.min(chart.width, ratio * chart.width));
+    const index = series.points.length === 1
+      ? 0
+      : Math.round((x / chart.width) * (series.points.length - 1));
+    setHoveredIndex(index);
+  }
 
   return (
     <AppShell title="Progress">
       {error && (
-        <div className="rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+        <Card className="border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
           {error}
-        </div>
+        </Card>
       )}
 
       {loading ? (
-        <div className="rounded-md border border-zinc-700 bg-zinc-800 p-5 text-zinc-300">
+        <Card padding="lg" className="text-[var(--ui-text-secondary)]">
           Loading progress...
-        </div>
+        </Card>
       ) : programs.length === 0 ? (
-        <div className="rounded-md border border-zinc-700 bg-zinc-800 p-5 text-zinc-300">
+        <Card padding="lg" className="text-[var(--ui-text-secondary)]">
           No progress data yet. Complete a workout session to start tracking trends.
-        </div>
+        </Card>
       ) : (
-        <div className="space-y-4">
-          <section className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-2 text-sm text-zinc-400">Program</div>
+        <div className="space-y-6">
+          <Card>
+            <SectionHeader
+              title="Program"
+              action={
+                selectedProgram?.isActive ? <Badge variant="active">Active</Badge> : null
+              }
+            />
             <select
-              className="w-full rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+              className="w-full rounded-md border border-[var(--ui-border)] bg-zinc-900 px-3 py-2 text-[var(--ui-text-primary)] outline-none"
               value={selectedProgramId ?? ''}
               onChange={(e) => setSelectedProgramId(Number(e.target.value))}
             >
@@ -245,153 +287,170 @@ export default function ProgressPage() {
                 </option>
               ))}
             </select>
-          </section>
+          </Card>
 
-          <section className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-2 text-sm text-zinc-400">Program day</div>
-            <div className="flex flex-wrap gap-2">
-              {(selectedProgram?.days ?? []).map((day) => {
-                const active = day.id === selectedProgramDayId;
-                return (
-                  <button
-                    key={day.id}
-                    className={
-                      active
-                        ? 'rounded-md border border-zinc-500 bg-zinc-700 px-3 py-2 text-sm font-semibold text-zinc-100'
-                        : 'rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-700'
-                    }
-                    onClick={() => setSelectedProgramDayId(day.id)}
-                  >
-                    #{day.order} - {day.name}
-                  </button>
-                );
-              })}
-            </div>
-          </section>
+          <Card>
+            <SectionHeader title="Program day" />
+            <SegmentedControl
+              ariaLabel="Program day"
+              value={selectedProgramDayId ?? -1}
+              options={(selectedProgram?.days ?? []).map((day) => ({
+                value: day.id,
+                label: `#${day.order} - ${day.name}`,
+              }))}
+              onChange={(value) => setSelectedProgramDayId(value)}
+            />
+          </Card>
 
-          <section className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-2 text-sm text-zinc-400">Metric</div>
-            <div className="flex flex-wrap gap-2">
-              <button
-                className={
-                  metric === 'e1rm'
-                    ? 'rounded-md border border-zinc-500 bg-zinc-700 px-3 py-2 text-sm font-semibold text-zinc-100'
-                    : 'rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-700'
-                }
-                onClick={() => setMetric('e1rm')}
-              >
-                Strength (best e1RM)
-              </button>
-              <button
-                className={
-                  metric === 'volume'
-                    ? 'rounded-md border border-zinc-500 bg-zinc-700 px-3 py-2 text-sm font-semibold text-zinc-100'
-                    : 'rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-700'
-                }
-                onClick={() => setMetric('volume')}
-              >
-                Workload (volume)
-              </button>
-            </div>
-          </section>
+          <Card>
+            <SectionHeader title="Metric" />
+            <SegmentedControl
+              ariaLabel="Metric"
+              value={metric}
+              options={[
+                { value: 'e1rm', label: 'Strength (best e1RM)' },
+                { value: 'volume', label: 'Workload (volume)' },
+              ]}
+              onChange={(value) => setMetric(value)}
+            />
+          </Card>
 
-          <section className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-3 flex items-center justify-between">
-              <div className="text-sm text-zinc-400">
-                {metric === 'e1rm' ? 'Best e1RM per completed session' : 'Total volume per completed session'}
-              </div>
-              <div className="text-xs text-zinc-500">
-                EMA alpha: {series?.alpha ?? 0.25}
-              </div>
-            </div>
+          <Card>
+            <SectionHeader
+              title={metric === 'e1rm' ? 'Best e1RM per completed session' : 'Total volume per completed session'}
+              action={<Badge>EMA alpha: {series?.alpha ?? 0.25}</Badge>}
+            />
 
             {seriesLoading ? (
-              <p className="text-sm text-zinc-400">Loading series...</p>
+              <p className="text-sm text-[var(--ui-text-secondary)]">Loading series...</p>
             ) : !series || series.points.length === 0 ? (
-              <p className="text-sm text-zinc-400">No completed sessions for this program day yet.</p>
+              <p className="text-sm text-[var(--ui-text-secondary)]">No completed sessions for this program day yet.</p>
             ) : (
-              <div className="space-y-3">
+              <div className="space-y-4">
                 <div className="overflow-x-auto">
                   <svg
                     viewBox={`0 0 ${chart.width} ${chart.height}`}
-                    className="h-[320px] min-w-[720px] w-full rounded-md border border-zinc-700 bg-zinc-900"
+                    className="h-[320px] min-w-[720px] w-full rounded-lg border border-[var(--ui-border)] bg-gradient-to-b from-[var(--ui-card-2)] to-[var(--ui-card)]"
                     role="img"
                     aria-label="Progress trend chart"
+                    onMouseMove={onChartMouseMove}
+                    onMouseLeave={() => setHoveredIndex(null)}
                   >
-                    <rect x="0" y="0" width={chart.width} height={chart.height} fill="#0a0a0a" />
-                    <line
-                      x1={chart.padding}
-                      y1={chart.height - chart.padding}
-                      x2={chart.width - chart.padding}
-                      y2={chart.height - chart.padding}
-                      stroke="#3f3f46"
-                      strokeWidth="1"
-                    />
-                    <line
-                      x1={chart.padding}
-                      y1={chart.padding}
-                      x2={chart.padding}
-                      y2={chart.height - chart.padding}
-                      stroke="#3f3f46"
-                      strokeWidth="1"
-                    />
+                    {Array.from({ length: 4 }).map((_, index) => {
+                      const y = chart.yPadding + (index / 3) * (chart.height - chart.yPadding * 2);
+                      return (
+                        <line
+                          key={`grid-${index}`}
+                          x1={0}
+                          y1={y}
+                          x2={chart.width}
+                          y2={y}
+                          stroke="#a1a1aa1f"
+                          strokeWidth="1"
+                        />
+                      );
+                    })}
 
                     {chart.raw.points.length > 1 && (
                       <polyline
                         fill="none"
                         stroke="#a1a1aa"
-                        strokeWidth="1.5"
+                        strokeWidth="2"
+                        strokeOpacity="0.35"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
                         points={pointsToPolyline(chart.raw.points)}
                       />
                     )}
 
                     {chart.ema.points.length > 1 && (
-                      <polyline
-                        fill="none"
-                        stroke="#22c55e"
-                        strokeWidth="3"
-                        points={pointsToPolyline(chart.ema.points)}
-                      />
+                      <>
+                        <polygon
+                          fill="rgba(45,212,191,0.08)"
+                          points={pointsToArea(chart.ema.points, chart.height - chart.yPadding)}
+                        />
+                        <polyline
+                          fill="none"
+                          stroke="#2dd4bf"
+                          strokeWidth="3"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          points={pointsToPolyline(chart.ema.points)}
+                        />
+                      </>
                     )}
 
-                    {chart.raw.points.map((point, index) => (
-                      <circle key={`raw-${index}`} cx={point.x} cy={point.y} r="2.6" fill="#d4d4d8" />
-                    ))}
+                    {hoveredPoint && (
+                      <>
+                        <line
+                          x1={hoveredPoint.x}
+                          y1={0}
+                          x2={hoveredPoint.x}
+                          y2={chart.height}
+                          stroke="#a1a1aa44"
+                          strokeWidth="1"
+                          strokeDasharray="4 4"
+                        />
+                        <g>
+                          <rect
+                            x={Math.min(Math.max(hoveredPoint.x + 10, 8), chart.width - 212)}
+                            y={10}
+                            width={204}
+                            height={72}
+                            rx={8}
+                            fill="var(--ui-card-2)"
+                            stroke="var(--ui-border)"
+                          />
+                          <text
+                            x={Math.min(Math.max(hoveredPoint.x + 20, 18), chart.width - 202)}
+                            y={30}
+                            fill="var(--ui-text-secondary)"
+                            fontSize="11"
+                          >
+                            {formatDate(hoveredPoint.point.date)}
+                          </text>
+                          <text
+                            x={Math.min(Math.max(hoveredPoint.x + 20, 18), chart.width - 202)}
+                            y={50}
+                            fill="var(--ui-text-primary)"
+                            fontSize="12"
+                          >
+                            Raw: {formatMetricValue(hoveredPoint.point.value, metric)}
+                          </text>
+                          <text
+                            x={Math.min(Math.max(hoveredPoint.x + 20, 18), chart.width - 202)}
+                            y={68}
+                            fill="var(--ui-text-primary)"
+                            fontSize="12"
+                          >
+                            EMA: {formatMetricValue(hoveredPoint.point.emaValue, metric)}
+                          </text>
+                        </g>
+                      </>
+                    )}
                   </svg>
                 </div>
 
-                <div className="flex items-center justify-between text-xs text-zinc-500">
+                <div className="flex items-center justify-between text-xs text-[var(--ui-text-secondary)]">
                   <span>{formatDate(series.points[0]?.date ?? null)}</span>
                   <span>{formatDate(series.points[series.points.length - 1]?.date ?? null)}</span>
                 </div>
 
-                <div className="grid grid-cols-2 gap-2 text-sm text-zinc-300 md:grid-cols-4">
-                  <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                    <div className="text-xs text-zinc-500">Sessions</div>
-                    <div className="text-base font-semibold">{series.points.length}</div>
-                  </div>
-                  <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                    <div className="text-xs text-zinc-500">Latest raw</div>
-                    <div className="text-base font-semibold">
-                      {formatMetricValue(series.points[series.points.length - 1]?.value ?? null, metric)}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                    <div className="text-xs text-zinc-500">Latest EMA</div>
-                    <div className="text-base font-semibold">
-                      {formatMetricValue(series.points[series.points.length - 1]?.emaValue ?? null, metric)}
-                    </div>
-                  </div>
-                  <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                    <div className="text-xs text-zinc-500">Range</div>
-                    <div className="text-base font-semibold">
-                      {chart.min.toFixed(1)} - {chart.max.toFixed(1)}
-                    </div>
-                  </div>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                  <StatCard label="Sessions" value={series.points.length} />
+                  <StatCard
+                    label="Latest raw"
+                    value={formatMetricValue(series.points[series.points.length - 1]?.value ?? null, metric)}
+                  />
+                  <StatCard
+                    label="Latest EMA"
+                    value={formatMetricValue(series.points[series.points.length - 1]?.emaValue ?? null, metric)}
+                  />
+                  <StatCard label="Range" value={`${chart.min.toFixed(1)} - ${chart.max.toFixed(1)}`} />
                 </div>
               </div>
             )}
-          </section>
+          </Card>
         </div>
       )}
     </AppShell>

--- a/apps/web/src/app/workouts/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/workouts/sessions/[sessionId]/page.tsx
@@ -2,9 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { AppShell } from '@/components/app-shell';
+import { Badge } from '@/components/ui/badge';
+import { PrimaryButton, SecondaryButton } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeader } from '@/components/ui/section-header';
+import { StatCard } from '@/components/ui/stat-card';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
-import { AppShell } from '@/components/app-shell';
 
 type SessionDetails = {
   id: number;
@@ -108,37 +113,29 @@ export default function SessionPage() {
       title={`Workout Session #${sessionId}`}
       actions={
         <>
-          <button
-            onClick={load}
-            className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
-          >
-            Refresh
-          </button>
-          <button
-            onClick={finish}
-            className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white"
-          >
-            Finish
-          </button>
+          <SecondaryButton onClick={load}>Refresh</SecondaryButton>
+          <PrimaryButton onClick={finish}>Finish</PrimaryButton>
         </>
       }
     >
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && <Card className="border-red-500/40 bg-red-500/10 text-sm text-red-300">{error}</Card>}
 
       {!details ? (
-        <p>Loading...</p>
+        <Card className="text-sm text-[var(--ui-text-secondary)]">Loading...</Card>
       ) : (
-        <div className="space-y-4">
-          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="font-semibold">{details.program.name}</div>
-            <div className="text-sm text-zinc-300">
-              {details.programDay.name} (Day {details.programDay.order})
+        <div className="space-y-6">
+          <Card padding="lg" className="space-y-4">
+            <SectionHeader title={details.program.name} action={<Badge>{details.program.type}</Badge>} />
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <StatCard label="Program Day" value={`${details.programDay.name} (#${details.programDay.order})`} />
+              <StatCard label="Status" value={details.endedAt ? 'Finished' : 'Active'} />
+              <StatCard label="Exercises" value={details.exercises.length} />
             </div>
-            <div className="mt-1 text-xs text-zinc-400">
+            <div className="text-xs text-[var(--ui-text-secondary)]">
               Started: {new Date(details.startedAt).toLocaleString()}
               {details.endedAt ? ` | Ended: ${new Date(details.endedAt).toLocaleString()}` : ''}
             </div>
-          </div>
+          </Card>
 
           {details.exercises.map((block) => {
             const de = block.dayExercise;
@@ -146,41 +143,35 @@ export default function SessionPage() {
             const busy = busyKey === `add-${de.id}`;
 
             return (
-              <div
-                key={de.id}
-                className="space-y-3 rounded-md border border-zinc-700 bg-zinc-800 p-4"
-              >
-                <div className="flex items-baseline justify-between">
-                  <div className="font-semibold">
-                    {de.order}. {de.exercise.name}
-                  </div>
-                  <div className="text-sm text-zinc-400">
-                    Target: {de.targetSets} sets | {de.minReps}-{de.maxReps} reps
-                  </div>
-                </div>
+              <Card key={de.id} className="space-y-4">
+                <SectionHeader
+                  title={`${de.order}. ${de.exercise.name}`}
+                  subtitle={performed.length === 0 ? 'No sets yet' : `${performed.length} set${performed.length > 1 ? 's' : ''} completed`}
+                  action={<Badge>{`Target ${de.targetSets} | ${de.minReps}-${de.maxReps} reps`}</Badge>}
+                />
 
-                <div className="space-y-1 text-sm">
+                <div className="space-y-1 rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3 text-sm">
                   {performed.length === 0 ? (
-                    <div className="text-zinc-400">No sets yet</div>
+                    <div className="text-[var(--ui-text-secondary)]">No sets yet</div>
                   ) : (
                     performed.map((s) => (
                       <div key={`${de.id}-${s.setNumber}`} className="flex gap-3">
-                        <span className="w-14 text-zinc-400">Set {s.setNumber}</span>
+                        <span className="w-14 text-[var(--ui-text-secondary)]">Set {s.setNumber}</span>
                         <span>{s.reps} reps</span>
-                        <span className="text-zinc-400">x</span>
+                        <span className="text-[var(--ui-text-secondary)]">x</span>
                         <span>{s.weight} kg</span>
                       </div>
                     ))
                   )}
                 </div>
 
-                <div className="flex items-end gap-2">
+                <div className="grid gap-3 md:grid-cols-[120px,160px,auto] md:items-end">
                   <label className="flex flex-col gap-1">
-                    <span className="text-xs text-zinc-400">Reps</span>
+                    <span className="text-xs text-[var(--ui-text-secondary)]">Reps</span>
                     <input
                       type="number"
                       min={1}
-                      className="w-24 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                      className="w-full rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] px-3 py-2 outline-none"
                       value={repsBy[de.id] ?? 8}
                       onChange={(e) =>
                         setRepsBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
@@ -189,12 +180,12 @@ export default function SessionPage() {
                   </label>
 
                   <label className="flex flex-col gap-1">
-                    <span className="text-xs text-zinc-400">Weight (kg)</span>
+                    <span className="text-xs text-[var(--ui-text-secondary)]">Weight (kg)</span>
                     <input
                       type="number"
                       min={0}
                       step={0.5}
-                      className="w-32 rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2 outline-none"
+                      className="w-full rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] px-3 py-2 outline-none"
                       value={weightBy[de.id] ?? 0}
                       onChange={(e) =>
                         setWeightBy((prev) => ({ ...prev, [de.id]: Number(e.target.value) }))
@@ -202,19 +193,19 @@ export default function SessionPage() {
                     />
                   </label>
 
-                  <button
+                  <PrimaryButton
                     disabled={busy || details.endedAt !== null}
                     onClick={() => addSet(de.id, performed.length)}
-                    className="rounded-md bg-zinc-100 px-4 py-2 font-semibold text-zinc-900 hover:bg-white disabled:opacity-50"
+                    className="w-full md:w-auto"
                   >
                     {details.endedAt
                       ? 'Session finished'
                       : busy
                         ? 'Adding...'
                         : `Add set ${performed.length + 1}`}
-                  </button>
+                  </PrimaryButton>
                 </div>
-              </div>
+              </Card>
             );
           })}
         </div>
@@ -222,4 +213,3 @@ export default function SessionPage() {
     </AppShell>
   );
 }
-

--- a/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
+++ b/apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { ArrowDown, ArrowUp, Minus, type LucideIcon } from 'lucide-react';
+import { SecondaryButton } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { SectionHeader } from '@/components/ui/section-header';
+import { StatCard } from '@/components/ui/stat-card';
 import { apiFetch } from '@/lib/api';
 import { getToken } from '@/lib/auth';
 import { AppShell } from '@/components/app-shell';
@@ -154,80 +158,66 @@ export default function SessionSummaryPage() {
     <AppShell
       title={`Summary - Session #${sessionId}`}
       actions={
-        <button
-          onClick={load}
-          className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-2 hover:bg-zinc-700"
-        >
+        <SecondaryButton onClick={load}>
           Refresh
-        </button>
+        </SecondaryButton>
       }
     >
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && <Card className="border-red-500/40 bg-red-500/10 text-sm text-red-300">{error}</Card>}
 
       {!data ? (
-        <p>Loading...</p>
+        <Card className="text-sm text-[var(--ui-text-secondary)]">Loading...</Card>
       ) : (
         <>
-          <div className="space-y-2 rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="flex items-baseline justify-between">
-              <div className="font-semibold">Workout totals</div>
-              <div className="text-sm text-zinc-300">Duration: {formatDuration(data.durationSeconds)}</div>
-            </div>
+          <Card className="space-y-3">
+            <SectionHeader
+              title="Workout totals"
+              action={<div className="text-sm text-[var(--ui-text-secondary)]">Duration: {formatDuration(data.durationSeconds)}</div>}
+            />
 
             <div className="grid grid-cols-3 gap-3 text-sm">
-              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                <div className="text-xs text-zinc-400">Sets</div>
-                <div className="text-lg font-semibold">{data.totals.totalSets}</div>
-              </div>
-
-              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                <div className="text-xs text-zinc-400">Reps</div>
-                <div className="text-lg font-semibold">{data.totals.totalReps}</div>
-              </div>
-
-              <div className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
-                <div className="text-xs text-zinc-400">Volume</div>
-                <div className="text-lg font-semibold">{Math.round(data.totals.totalVolume)}</div>
-              </div>
+              <StatCard label="Sets" value={data.totals.totalSets} className="text-lg" />
+              <StatCard label="Reps" value={data.totals.totalReps} className="text-lg" />
+              <StatCard label="Volume" value={Math.round(data.totals.totalVolume)} className="text-lg" />
             </div>
 
-            <div className="text-xs text-zinc-400">
+            <div className="text-xs text-[var(--ui-text-secondary)]">
               Started: {new Date(data.startedAt).toLocaleString()}
               {data.endedAt ? ` | Ended: ${new Date(data.endedAt).toLocaleString()}` : ''}
             </div>
-          </div>
+          </Card>
 
-          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-3 font-semibold">Muscle workload (hypertrophy signal)</div>
+          <Card>
+            <SectionHeader title="Muscle workload (hypertrophy signal)" />
 
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
               {sortedMuscles.map((m) => (
-                <div key={m.muscle} className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                <div key={m.muscle} className="rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3">
                   <div className="flex items-baseline justify-between">
                     <div className="font-semibold">
                       <ProgressMark state={m.hypertrophyProgress} />
                       {m.muscle}
                     </div>
-                    <div className="text-xs text-zinc-400">
+                    <div className="text-xs text-[var(--ui-text-secondary)]">
                       {m.currentTotalSets} sets | {m.currentTotalReps} reps
                     </div>
                   </div>
 
                   <div className="mt-2 grid grid-cols-3 gap-3 text-sm">
                     <div>
-                      <div className="text-xs text-zinc-400">Current volume</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Current volume</div>
                       <div className="font-semibold">{Math.round(m.currentTotalVolume)}</div>
                     </div>
 
                     <div>
-                      <div className="text-xs text-zinc-400">Previous volume</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Previous volume</div>
                       <div className="font-semibold">
                         {m.previousTotalVolume === null ? '-' : Math.round(m.previousTotalVolume)}
                       </div>
                     </div>
 
                     <div>
-                      <div className="text-xs text-zinc-400">Delta volume</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Delta volume</div>
                       <div className="font-semibold">
                         {m.volumeDelta === null
                           ? '-'
@@ -239,54 +229,54 @@ export default function SessionSummaryPage() {
               ))}
 
               {sortedMuscles.length === 0 && (
-                <div className="text-sm text-zinc-400">No muscle totals for this session.</div>
+                <div className="text-sm text-[var(--ui-text-secondary)]">No muscle totals for this session.</div>
               )}
             </div>
 
-            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-zinc-400">
+            <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-[var(--ui-text-secondary)]">
               <span>Legend:</span>
               <ProgressLegendItem state="IMPROVED" text="improved" />
               <ProgressLegendItem state="SAME" text="same" />
               <ProgressLegendItem state="REGRESSED" text="regressed" />
               <ProgressLegendItem state="NO_BASELINE" text="no baseline" />
             </div>
-          </div>
+          </Card>
 
-          <div className="rounded-md border border-zinc-700 bg-zinc-800 p-4">
-            <div className="mb-3 font-semibold">Strength signal (e1RM)</div>
+          <Card>
+            <SectionHeader title="Strength signal (e1RM)" />
 
             <div className="space-y-3">
               {sortedExercises.map((ex) => (
-                <div key={ex.exerciseId} className="rounded-md border border-zinc-700 bg-zinc-900 p-3">
+                <div key={ex.exerciseId} className="rounded-md border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3">
                   <div className="flex items-baseline justify-between">
                     <div className="font-semibold">
                       <ProgressMark state={ex.strengthProgress} />
-                      {ex.name} <span className="text-xs text-zinc-400">({ex.primaryMuscle})</span>
+                      {ex.name} <span className="text-xs text-[var(--ui-text-secondary)]">({ex.primaryMuscle})</span>
                     </div>
 
-                    <div className="text-sm text-zinc-400">
+                    <div className="text-sm text-[var(--ui-text-secondary)]">
                       {ex.sets} sets | {ex.repsTotal} reps | vol {Math.round(ex.currentVolume)}
                     </div>
                   </div>
 
                   <div className="mt-2 grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
                     <div>
-                      <div className="text-xs text-zinc-400">Current best e1RM</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Current best e1RM</div>
                       <div className="font-semibold">{formatBestE1rmSet(ex.currentBestE1rmSet)}</div>
                     </div>
 
                     <div>
-                      <div className="text-xs text-zinc-400">Previous best e1RM</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Previous best e1RM</div>
                       <div className="font-semibold">{formatBestE1rmSet(ex.previousBestE1rmSet)}</div>
                     </div>
 
                     <div>
-                      <div className="text-xs text-zinc-400">Delta e1RM</div>
+                      <div className="text-xs text-[var(--ui-text-secondary)]">Delta e1RM</div>
                       <div className="font-semibold">{formatE1rmDelta(ex.currentBestE1rmSet, ex.previousBestE1rmSet)}</div>
                     </div>
                   </div>
 
-                  <div className="mt-2 text-xs text-zinc-400">
+                  <div className="mt-2 text-xs text-[var(--ui-text-secondary)]">
                     Hypertrophy: <ProgressMark state={ex.hypertrophyProgress} />
                     Delta volume{' '}
                     {ex.volumeDelta === null
@@ -297,18 +287,18 @@ export default function SessionSummaryPage() {
               ))}
 
               {sortedExercises.length === 0 && (
-                <div className="text-sm text-zinc-400">No performed sets in this session.</div>
+                <div className="text-sm text-[var(--ui-text-secondary)]">No performed sets in this session.</div>
               )}
             </div>
 
-            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-zinc-400">
+            <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-[var(--ui-text-secondary)]">
               <span>Legend:</span>
               <ProgressLegendItem state="IMPROVED" text="improved" />
               <ProgressLegendItem state="SAME" text="same" />
               <ProgressLegendItem state="REGRESSED" text="regressed" />
               <ProgressLegendItem state="NO_BASELINE" text="no baseline" />
             </div>
-          </div>
+          </Card>
         </>
       )}
     </AppShell>

--- a/apps/web/src/components/app-nav.tsx
+++ b/apps/web/src/components/app-nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { buttonClass } from '@/components/ui/button';
 
 type NavItem = {
   href: string;
@@ -19,9 +20,10 @@ function isActive(pathname: string, href: string) {
 }
 
 function itemClass(active: boolean) {
-  return active
-    ? 'rounded-md border border-zinc-600 bg-zinc-700 px-3 py-2 text-sm font-semibold text-zinc-100'
-    : 'rounded-md border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100';
+  return buttonClass(
+    active ? 'primary' : 'secondary',
+    active ? 'px-3 py-2 text-sm' : 'px-3 py-2 text-sm text-[var(--ui-text-secondary)]',
+  );
 }
 
 export function AppNav() {
@@ -29,8 +31,8 @@ export function AppNav() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 hidden border-b border-zinc-800 bg-zinc-900/95 backdrop-blur md:block">
-        <div className="mx-auto flex max-w-3xl items-center gap-2 px-6 py-3">
+      <nav className="sticky top-0 z-40 hidden border-b border-[var(--ui-border)] bg-black/40 backdrop-blur md:block">
+        <div className="mx-auto flex max-w-5xl items-center gap-2 px-6 py-3">
           {NAV_ITEMS.map((item) => (
             <Link
               key={item.href}
@@ -43,8 +45,8 @@ export function AppNav() {
         </div>
       </nav>
 
-      <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-zinc-800 bg-zinc-900/95 px-4 py-3 backdrop-blur md:hidden">
-        <div className="mx-auto grid max-w-3xl grid-cols-3 gap-2">
+      <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-[var(--ui-border)] bg-black/40 px-4 py-3 backdrop-blur md:hidden">
+        <div className="mx-auto grid max-w-5xl grid-cols-3 gap-2">
           {NAV_ITEMS.map((item) => (
             <Link
               key={item.href}

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -11,11 +11,11 @@ type AppShellProps = {
 
 export function AppShell({ title, actions, children }: AppShellProps) {
   return (
-    <main className="min-h-screen bg-zinc-900 text-zinc-100">
+    <main className="min-h-screen text-[var(--ui-text-primary)]">
       <AppNav />
 
-      <div className="px-4 py-6 pb-24 md:px-6 md:py-8 md:pb-10">
-        <div className="mx-auto max-w-3xl space-y-6">
+      <div className="px-4 py-6 pb-24 md:px-6 md:pb-10">
+        <div className="mx-auto max-w-5xl space-y-6">
           <div className="flex items-center justify-between gap-3">
             <h1 className="text-3xl font-bold md:text-4xl">{title}</h1>
             {actions ? <div className="flex items-center gap-2">{actions}</div> : null}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,22 @@
+import { HTMLAttributes } from 'react';
+
+type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  variant?: 'subtle' | 'active';
+};
+
+export function Badge({ className, variant = 'subtle', ...props }: BadgeProps) {
+  const variantClass =
+    variant === 'active'
+      ? 'border-emerald-500/50 bg-emerald-500/15 text-emerald-300'
+      : 'border-[var(--ui-border)] bg-zinc-900 text-[var(--ui-text-secondary)]';
+
+  const classes = [
+    'inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium',
+    variantClass,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <span className={classes} {...props} />;
+}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,63 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'danger';
+
+type BaseButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  className?: string;
+};
+
+function joinClasses(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+function baseButtonClass(className?: string) {
+  return joinClasses(
+    'inline-flex items-center justify-center rounded-md border px-3 py-2 text-sm font-semibold transition-[background-color,border-color,box-shadow,color]',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ui-accent)]/60',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    className,
+  );
+}
+
+export function buttonClass(variant: ButtonVariant, className?: string) {
+  if (variant === 'primary') {
+    return baseButtonClass(
+      joinClasses(
+        'border-[var(--ui-accent)] bg-[var(--ui-accent)] text-zinc-950',
+        'shadow-sm shadow-[0_0_20px_rgba(45,212,191,0.15)]',
+        'hover:border-[var(--ui-accent-hover)] hover:bg-[var(--ui-accent-hover)] hover:shadow-[0_0_24px_rgba(45,212,191,0.25)]',
+        className,
+      ),
+    );
+  }
+  if (variant === 'danger') {
+    return baseButtonClass(
+      joinClasses('border-red-500/60 bg-transparent text-red-300 hover:bg-red-500/10', className),
+    );
+  }
+  return baseButtonClass(
+    joinClasses(
+      'border-[var(--ui-border)] bg-zinc-900 text-[var(--ui-text-primary)] hover:bg-zinc-800',
+      className,
+    ),
+  );
+}
+
+function BaseButton({ className, ...props }: BaseButtonProps) {
+  return <button type="button" className={baseButtonClass(className)} {...props} />;
+}
+
+export function PrimaryButton(props: BaseButtonProps) {
+  const { className, ...rest } = props;
+  return <BaseButton className={buttonClass('primary', className)} {...rest} />;
+}
+
+export function SecondaryButton(props: BaseButtonProps) {
+  const { className, ...rest } = props;
+  return <BaseButton className={buttonClass('secondary', className)} {...rest} />;
+}
+
+export function DangerButton(props: BaseButtonProps) {
+  const { className, ...rest } = props;
+  return <BaseButton className={buttonClass('danger', className)} {...rest} />;
+}

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,18 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+type CardProps = ComponentPropsWithoutRef<'section'> & {
+  padding?: 'md' | 'lg';
+};
+
+export function Card({ className, padding = 'md', ...props }: CardProps) {
+  const paddingClass = padding === 'lg' ? 'p-5' : 'p-4';
+  const classes = [
+    'rounded-xl border border-[var(--ui-border)] bg-gradient-to-b from-[var(--ui-card-2)] to-[var(--ui-card)] ring-1 ring-white/8 shadow-sm shadow-black/40',
+    paddingClass,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <section className={classes} {...props} />;
+}

--- a/apps/web/src/components/ui/section-header.tsx
+++ b/apps/web/src/components/ui/section-header.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+type SectionHeaderProps = {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export function SectionHeader({ title, subtitle, action, className }: SectionHeaderProps) {
+  const classes = ['mb-3 flex items-center justify-between gap-3', className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes}>
+      <div>
+        <h2 className="text-sm font-semibold text-[var(--ui-text-primary)]">{title}</h2>
+        {subtitle ? <p className="mt-0.5 text-xs text-[var(--ui-text-secondary)]">{subtitle}</p> : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/segmented-control.tsx
+++ b/apps/web/src/components/ui/segmented-control.tsx
@@ -1,0 +1,55 @@
+import { PrimaryButton, SecondaryButton } from './button';
+
+type SegmentedOption<T extends string | number> = {
+  value: T;
+  label: string;
+};
+
+type SegmentedControlProps<T extends string | number> = {
+  value: T;
+  options: SegmentedOption<T>[];
+  onChange: (value: T) => void;
+  ariaLabel: string;
+  className?: string;
+};
+
+export function SegmentedControl<T extends string | number>({
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  className,
+}: SegmentedControlProps<T>) {
+  const classes = ['flex flex-wrap gap-3', className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes} role="radiogroup" aria-label={ariaLabel}>
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          isActive ? (
+            <PrimaryButton
+              key={String(option.value)}
+              role="radio"
+              aria-checked={isActive}
+              className="text-zinc-950 ring-1 ring-[var(--ui-accent)]/30 shadow-sm"
+              onClick={() => onChange(option.value)}
+            >
+              {option.label}
+            </PrimaryButton>
+          ) : (
+            <SecondaryButton
+              key={String(option.value)}
+              role="radio"
+              aria-checked={isActive}
+              className="text-[var(--ui-text-secondary)]"
+              onClick={() => onChange(option.value)}
+            >
+              {option.label}
+            </SecondaryButton>
+          )
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/stat-card.tsx
+++ b/apps/web/src/components/ui/stat-card.tsx
@@ -1,0 +1,23 @@
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  hint?: string;
+  className?: string;
+};
+
+export function StatCard({ label, value, hint, className }: StatCardProps) {
+  const classes = [
+    'rounded-lg border border-[var(--ui-border)] bg-[var(--ui-card-2)] p-3',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes}>
+      <div className="text-xs text-[var(--ui-text-secondary)]">{label}</div>
+      <div className="text-base font-semibold text-[var(--ui-text-primary)]">{value}</div>
+      {hint ? <div className="mt-1 text-xs text-[var(--ui-text-secondary)]">{hint}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
- Built a reusable UI foundation and applied it across core web screens.
- Upgraded visual theme to a premium graphite dark style with mint-teal accent.
- Refined Progress chart visuals/interactions.
- Brought Workout Session UI to parity with the new design system.

## Why
- The app looked inconsistent and dev-like across screens.
- We needed a shared UI baseline (cards/buttons/sections/surfaces) before deeper UX work.
- Progress and Workout Session needed stronger visual hierarchy and better mobile-ready structure.

## Scope
- Added reusable UI primitives under `apps/web/src/components/ui`:
  - `Card`
  - `SectionHeader`
  - `PrimaryButton`, `SecondaryButton`, `DangerButton`
  - `SegmentedControl`
  - `StatCard`
  - `Badge`
- Added and iterated theme tokens/surfaces in `apps/web/src/app/globals.css`.
- Applied primitives and tokenized styling to:
  - Login (`apps/web/src/app/page.tsx`)
  - Home (`apps/web/src/app/home/page.tsx`)
  - Programs (`apps/web/src/app/programs/page.tsx`)
  - Progress (`apps/web/src/app/progress/page.tsx`)
  - Workout Session (`apps/web/src/app/workouts/sessions/[sessionId]/page.tsx`)
  - Session Summary (`apps/web/src/app/workouts/sessions/[sessionId]/summary/page.tsx`)
- Updated shell/nav consistency:
  - `apps/web/src/components/app-shell.tsx`
  - `apps/web/src/components/app-nav.tsx`

## Out of scope
- No API contract changes.
- No business logic changes.
- No routing changes.
- No metric/formula changes.

## Implementation details
- Theme:
  - premium dark tokens with card/card-2 surfaces and border tuning.
  - mint-teal accent (`--ui-accent`, `--ui-accent-hover`) for primary actions.
- Cards:
  - gradient surface, subtle rim light, and soft shadow for separation.
- Buttons:
  - shared variant utility + subtle mint glow on primary actions.
- Segmented control:
  - semantic `radiogroup`/`radio` roles.
  - active mint ring/shadow treatment.
- Progress chart:
  - removed point dots.
  - raw vs EMA stroke hierarchy.
  - subtle EMA area fill.
  - integrated chart surface (no pure black background).
  - edge-to-edge X plotting (no side inset).
  - rounded stroke caps/joins.
  - low-opacity horizontal grid lines.
  - hover hairline + tooltip (date/raw/EMA), UI-only.
- Workout Session page:
  - standardized cards/headers/buttons/badges/stat cards.
  - tokenized inputs and improved responsive spacing.
  - preserved existing fetch/add-set/finish behavior.

## How to test
1. Run:
   - `npm run lint` (in `apps/web`)
   - `npm run build` (in `apps/web`)
2. Manually verify:
   - `/` login screen uses new primitives and centered card layout.
   - `/home`, `/programs`, `/progress` share consistent card/button/surface styling.
   - Progress chart:
     - no white points
     - EMA + raw hierarchy visible
     - subtle area under EMA
     - tooltip + vertical guide on hover
     - line starts at left edge and ends at right edge
   - `/workouts/sessions/[sessionId]` uses parity styling with new primitives and unchanged flow.
   - `/workouts/sessions/[sessionId]/summary` uses new surfaces/primitives consistently.

## Notes
- Lint still reports 2 pre-existing warnings in `apps/web/src/app/page.tsx`:
  - missing `router` dependency in `useEffect`
  - missing `loadPrograms` dependency in `useEffect`
- No docs update required (`.internal-docs`) since API/logic/contracts were unchanged.

## Closes
Closes #69
